### PR TITLE
[FE] Ambienti di test e produzione

### DIFF
--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -872,6 +872,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "description": "Back Office environment",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -1220,6 +1220,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "description": "Back Office environment",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2351,6 +2361,21 @@
   },
   "components": {
     "schemas": {
+      "BackOfficeConfigurationsResource": {
+        "title": "BackOfficeConfigurationsResource",
+        "required": ["environment", "url"],
+        "type": "object",
+        "properties": {
+          "environment": {
+            "type": "string",
+            "description": "Back Office environment"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL that redirects to the back-office section, where is possible to manage the product"
+          }
+        }
+      },
       "CertifiedFieldResourceOfstring": {
         "title": "CertifiedFieldResourceOfstring",
         "required": ["certified", "value"],
@@ -2860,6 +2885,13 @@
             "type": "boolean",
             "description": "flag indicating whether the logged user has the authorization to manage the product",
             "example": false
+          },
+          "backOfficeEnvironmentConfigurations": {
+            "type": "array",
+            "description": "Environment-specific configurations for back-office redirection with Token Exchange",
+            "items": {
+              "$ref": "#/components/schemas/BackOfficeConfigurationsResource"
+            }
           },
           "children": {
             "type": "array",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mui/x-data-grid": "^5.0.1",
     "@mui/x-data-grid-generator": "^5.0.1",
     "@pagopa/mui-italia": "^0.7.1",
-    "@pagopa/selfcare-common-frontend": "^1.12.1",
+    "@pagopa/selfcare-common-frontend": "^1.12.12",
     "@types/react-router-dom": "^5.1.8",
     "@types/react-router-hash-link": "^2.4.5",
     "axios": "^0.23.0",

--- a/src/api/DashboardApiClient.ts
+++ b/src/api/DashboardApiClient.ts
@@ -69,7 +69,7 @@ export const DashboardApi = {
     productId: string,
     environment?: string
   ): Promise<IdentityTokenResource> => {
-    const result = await apiClient.exchangeUsingGET({
+    const result = await apiClient.retrieveProductBackofficeUsingGET({
       productId,
       institutionId,
       environment,

--- a/src/api/DashboardApiClient.ts
+++ b/src/api/DashboardApiClient.ts
@@ -66,11 +66,13 @@ export const DashboardApi = {
 
   getTokenExchange: async (
     institutionId: string,
-    productId: string
+    productId: string,
+    environment?: string
   ): Promise<IdentityTokenResource> => {
     const result = await apiClient.exchangeUsingGET({
       productId,
       institutionId,
+      environment,
     });
     return extractResponse(result, 200, onRedirectToLogin);
   },

--- a/src/api/__mocks__/DashboardApiClient.ts
+++ b/src/api/__mocks__/DashboardApiClient.ts
@@ -266,8 +266,11 @@ export const DashboardApi = {
   getProducts: async (): Promise<Array<ProductsResource>> =>
     new Promise((resolve) => resolve(mockedProductResources)),
 
-  getTokenExchange: async (_partyId: string, _productId: string): Promise<IdentityTokenResource> =>
-    new Promise((resolve) => resolve({ token: 'DUMMYTOKEN' })),
+  getTokenExchange: async (
+    _partyId: string,
+    _productId: string,
+    _environment?: string
+  ): Promise<IdentityTokenResource> => new Promise((resolve) => resolve({ token: 'DUMMYTOKEN' })),
 
   getProductRoles: async (_productId: string): Promise<Array<ProductRoleMappingsResource>> =>
     new Promise((resolve) => resolve(mockedProductRoles)),

--- a/src/hooks/useTokenExchange.ts
+++ b/src/hooks/useTokenExchange.ts
@@ -13,6 +13,9 @@ export const useTokenExchange = () => {
   const addError = useErrorDispatcher();
   const setLoading = useLoading(LOADING_TASK_TOKEN_EXCHANGE);
 
+  /* TODO SELC-1600 adaptation to changes to the tokenExchange service agreed with the BE 
+  in order to obtain access to test environment when available for the product */
+
   const invokeProductBo = async (product: Product, selectedParty: Party): Promise<void> => {
     const result = validateUrlBO(product?.urlBO);
     if (result instanceof Error) {

--- a/src/hooks/useTokenExchange.ts
+++ b/src/hooks/useTokenExchange.ts
@@ -13,11 +13,17 @@ export const useTokenExchange = () => {
   const addError = useErrorDispatcher();
   const setLoading = useLoading(LOADING_TASK_TOKEN_EXCHANGE);
 
-  /* TODO SELC-1600 adaptation to changes to the tokenExchange service agreed with the BE 
-  in order to obtain access to test environment when available for the product */
-
-  const invokeProductBo = async (product: Product, selectedParty: Party): Promise<void> => {
-    const result = validateUrlBO(product?.urlBO);
+  const invokeProductBo = async (
+    product: Product,
+    selectedParty: Party,
+    selectedEnvironment?: string
+  ): Promise<void> => {
+    const selectedEnvironmentUrl = product.urlTest?.find(
+      (p) => p.environment === selectedEnvironment
+    )?.url;
+    const result = selectedEnvironmentUrl
+      ? validateUrlBO(selectedEnvironmentUrl)
+      : validateUrlBO(product?.urlBO);
     if (result instanceof Error) {
       addError({
         id: `ValidationUrlError-${product?.id}`,
@@ -30,7 +36,7 @@ export const useTokenExchange = () => {
     }
 
     setLoading(true);
-    retrieveTokenExchange(selectedParty, product)
+    retrieveTokenExchange(selectedParty, product, selectedEnvironment)
       .then((t) =>
         trackEvent(
           'DASHBOARD_OPEN_PRODUCT',

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -58,6 +58,13 @@ export default {
       activationOf: 'Attivo dal ',
       active: 'Attivo',
       manageButton: 'Gestisci',
+      activeProductsEnvModal: {
+        title: 'In quale ambiente vuoi entrare?',
+        message:
+          'L’ambiente di test ti permette di conoscere <1>{{productTitle}}</1> e fare prove in tutta sicurezza. L’ambiente di produzione è il prodotto vero e proprio.',
+        envProdButton: 'Produzione',
+        envTestButton: 'Test',
+      },
     },
     lastServiceActive: 'Ultimo servizio attivato: ',
     notActiveProductsSection: {

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -63,7 +63,7 @@ export default {
         message:
           'L’ambiente di test ti permette di conoscere <1>{{productTitle}}</1> e fare prove in tutta sicurezza. L’ambiente di produzione è il prodotto vero e proprio.',
         envProdButton: 'Produzione',
-        envTestButton: 'Test',
+        backButton: 'Annulla',
       },
     },
     lastServiceActive: 'Ultimo servizio attivato: ',

--- a/src/model/Product.tsx
+++ b/src/model/Product.tsx
@@ -10,7 +10,10 @@ export type Product = {
   logo: string;
   title: string;
   urlBO: string;
-  urlTest?: string;
+  urlTest?: Array<{
+    environment: string;
+    url: string;
+  }>;
   urlPublic?: string;
   tag?: string;
   userRole?: UserRole;

--- a/src/model/Product.tsx
+++ b/src/model/Product.tsx
@@ -10,6 +10,7 @@ export type Product = {
   logo: string;
   title: string;
   urlBO: string;
+  urlTest?: string;
   urlPublic?: string;
   tag?: string;
   userRole?: UserRole;

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -52,7 +52,6 @@ export default function ActiveProductCardContainer({ party, product }: Props) {
         onConfirmLabel={t('overview.activeProducts.activeProductsEnvModal.envProdButton')}
         onCloseLabel={t('overview.activeProducts.activeProductsEnvModal.envTestButton')}
         onConfirm={() => invokeProductBo(product, party)}
-        handleExit={() => setOpenChooseEnvModal(false)}
         handleClose={() => setOpenChooseEnvModal(false)} // TODO SELC-1600 Button to redirect in BO test enviroment product
       />
     </Grid>

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -50,9 +50,10 @@ export default function ActiveProductCardContainer({ party, product }: Props) {
           </Trans>
         }
         onConfirmLabel={t('overview.activeProducts.activeProductsEnvModal.envProdButton')}
-        onCloseLabel={t('overview.activeProducts.activeProductsEnvModal.envTestButton')}
+        onCloseLabel={t('overview.activeProducts.activeProductsEnvModal.backButton')}
         onConfirm={() => invokeProductBo(product, party)}
-        handleClose={() => setOpenChooseEnvModal(false)} // TODO SELC-1600 Button to redirect in BO test enviroment product
+        handleClose={() => setOpenChooseEnvModal(false)}
+        productEnvironments={product?.urlTest} // TODO SELC-1600 Button to redirect in BO test enviroment product
       />
     </Grid>
   );

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -51,9 +51,9 @@ export default function ActiveProductCardContainer({ party, product }: Props) {
         }
         onConfirmLabel={t('overview.activeProducts.activeProductsEnvModal.envProdButton')}
         onCloseLabel={t('overview.activeProducts.activeProductsEnvModal.backButton')}
-        onConfirm={() => invokeProductBo(product, party)}
+        onConfirm={(e) => invokeProductBo(product, party, (e.target as HTMLInputElement).value)}
         handleClose={() => setOpenChooseEnvModal(false)}
-        productEnvironments={product?.urlTest} // TODO SELC-1600 Button to redirect in BO test enviroment product
+        productEnvironments={product?.urlTest}
       />
     </Grid>
   );

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -1,6 +1,8 @@
 import { Grid, Typography } from '@mui/material';
+import SessionModal from '@pagopa/selfcare-common-frontend/components/SessionModal';
 import { formatDateAsLongString } from '@pagopa/selfcare-common-frontend/utils/utils';
-import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 import { useTokenExchange } from '../../../../../hooks/useTokenExchange';
 import { Party } from '../../../../../model/Party';
 import { Product } from '../../../../../model/Product';
@@ -14,6 +16,7 @@ type Props = {
 export default function ActiveProductCardContainer({ party, product }: Props) {
   const { t } = useTranslation();
   const { invokeProductBo } = useTokenExchange();
+  const [openChooseEnvModal, setOpenChooseEnvModal] = useState<boolean>(false);
   const isDisabled = product.authorized === false;
   const lastServiceActivationDate = undefined; // actually this info is not available
 
@@ -24,7 +27,9 @@ export default function ActiveProductCardContainer({ party, product }: Props) {
         cardTitle={product.title}
         buttonLabel={t('overview.activeProducts.manageButton')}
         urlLogo={product.logo}
-        btnAction={() => invokeProductBo(product, party)}
+        btnAction={() =>
+          product.urlTest ? setOpenChooseEnvModal(true) : invokeProductBo(product, party)
+        }
         party={party}
         product={product}
       />
@@ -34,6 +39,22 @@ export default function ActiveProductCardContainer({ party, product }: Props) {
             `${lastServiceActivationDate && formatDateAsLongString(lastServiceActivationDate)}`}
         </Typography>
       )}
+      <SessionModal
+        open={openChooseEnvModal}
+        title={t('overview.activeProducts.activeProductsEnvModal.title')}
+        message={
+          <Trans i18nKey="overview.activeProducts.activeProductsEnvModal.message">
+            L’ambiente di test ti permette di conoscere
+            <strong>{{ productTitle: product.title }}</strong> e fare prove in tutta sicurezza.
+            L’ambiente di produzione è il prodotto vero e proprio.
+          </Trans>
+        }
+        onConfirmLabel={t('overview.activeProducts.activeProductsEnvModal.envProdButton')}
+        onCloseLabel={t('overview.activeProducts.activeProductsEnvModal.envTestButton')}
+        onConfirm={() => invokeProductBo(product, party)}
+        handleExit={() => setOpenChooseEnvModal(false)}
+        handleClose={() => setOpenChooseEnvModal(false)} // TODO SELC-1600 Button to redirect in BO test enviroment product
+      />
     </Grid>
   );
 }

--- a/src/services/__mocks__/productService.ts
+++ b/src/services/__mocks__/productService.ts
@@ -80,9 +80,10 @@ export const mockedPartyProducts: Array<Product> = [
   {
     logo: 'https://selcdcheckoutsa.z6.web.core.windows.net/resources/products/prod-interop/logo.svg',
     id: 'prod-interop',
-    title: 'PDND',
+    title: 'Interoperabilità',
     description: 'Condividi dati con altri Enti in maniera semplice, sicura ed economica.',
     urlBO: 'http://PDND/bo#token=<IdentityToken>',
+    urlTest: '/', // TODO SELC-1600
     authorized: true,
     userRole: 'ADMIN',
     status: 'ACTIVE',

--- a/src/services/__mocks__/productService.ts
+++ b/src/services/__mocks__/productService.ts
@@ -83,7 +83,16 @@ export const mockedPartyProducts: Array<Product> = [
     title: 'Interoperabilità',
     description: 'Condividi dati con altri Enti in maniera semplice, sicura ed economica.',
     urlBO: 'http://PDND/bo#token=<IdentityToken>',
-    urlTest: [], // TODO SELC-1600
+    urlTest: [
+      {
+        environment: 'test1',
+        url: 'www.test1.com',
+      },
+      {
+        environment: 'test2',
+        url: 'www.test2.com',
+      },
+    ],
     authorized: true,
     userRole: 'ADMIN',
     status: 'ACTIVE',

--- a/src/services/__mocks__/productService.ts
+++ b/src/services/__mocks__/productService.ts
@@ -83,7 +83,7 @@ export const mockedPartyProducts: Array<Product> = [
     title: 'Interoperabilità',
     description: 'Condividi dati con altri Enti in maniera semplice, sicura ed economica.',
     urlBO: 'http://PDND/bo#token=<IdentityToken>',
-    urlTest: '/', // TODO SELC-1600
+    urlTest: [], // TODO SELC-1600
     authorized: true,
     userRole: 'ADMIN',
     status: 'ACTIVE',

--- a/src/services/tokenExchangeService.ts
+++ b/src/services/tokenExchangeService.ts
@@ -2,5 +2,11 @@ import { DashboardApi } from '../api/DashboardApiClient';
 import { Party } from '../model/Party';
 import { Product } from '../model/Product';
 
-export const retrieveTokenExchange = (selectedParty: Party, product: Product): Promise<string> =>
-  DashboardApi.getTokenExchange(selectedParty.partyId, product.id).then((r) => r.token);
+export const retrieveTokenExchange = (
+  selectedParty: Party,
+  product: Product,
+  environment?: string
+): Promise<string> =>
+  DashboardApi.getTokenExchange(selectedParty.partyId, product.id, environment).then(
+    (r) => r.token
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,10 +1935,10 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/selfcare-common-frontend@^1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.12.1.tgz#5c8fa19b3922d322c26d1068e70437760ca876f0"
-  integrity sha512-5S7DLPbsvkkvCJdKBk2aSr3pVwm0FaYiqz542KQqkt85Y47pNLhlkgvj2BnR134LcB8x3bsylKIA9sVo35wH7Q==
+"@pagopa/selfcare-common-frontend@^1.12.12":
+  version "1.12.12"
+  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.12.12.tgz#504863c838495567d93edd0b2c55c87d59f52bb9"
+  integrity sha512-x/DLm6dV9hJcXgihiWmfGiFdvYEhDrs6O6MJxZCFCbp10H9SJvpVuGNPL/VVPEMvXaZeMdNKTvrX5q00Wel4jQ==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION
This PR contains all task releated to the new management of test enviroments:
-> SELC-1598: Added the urlTest as array object with keys "environment" and "url"
-> SELC-1599: Create a intermedia popup with to direct to production or test environments (managed in the common library, the rendering of as many buttons as the test environments).
-> SELC-1600: Updated openApi, re-generate that with generate tool and also add new request of tokenExchange service in order to have back the token when we try to access to test environment