### PR TITLE
SELC-1648 Using the API that retrieve complete url with also the token instead of the previous API that retrieve only the token

### DIFF
--- a/openApi/scripts/api-b4f-dashboard_fixPreGen.js
+++ b/openApi/scripts/api-b4f-dashboard_fixPreGen.js
@@ -1,0 +1,8 @@
+const regexReplace = require('regex-replace');
+
+regexReplace(
+  /("format": *"uri",[\s]*"type": "string")/gi,
+  '"$ref": "#/definitions/STRINGWrapper"',
+  'openApi/generated/dashboard-swagger20.json',
+  { fileContentsOnly: true }
+);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettify": "prettier --write \"./**/*.{ts,tsx}\"",
     "generate": "npm-run-all generate:*",
     "clean:api-b4f-dashboard": "rimraf src/api/generated/b4f-dashboard && rimraf openApi/generated",
-    "generate:api-b4f-dashboard": "yarn run clean:api-b4f-dashboard && mkdirp openApi/generated && api-spec-converter --from=openapi_3 --to=swagger_2 openApi/dashboard-api-docs.json > openApi/generated/dashboard-swagger20.json && node ./node_modules/@pagopa/selfcare-common-frontend/utils/fixSwagger20ArraySchemaDef.js openApi/generated/dashboard-swagger20.json && gen-api-models --api-spec openApi/generated/dashboard-swagger20.json --out-dir src/api/generated/b4f-dashboard --no-strict --request-types --response-decoders --client && node openApi/scripts/api-b4f-dashboard_fixPostGen.js"
+    "generate:api-b4f-dashboard": "yarn run clean:api-b4f-dashboard && mkdirp openApi/generated && api-spec-converter --from=openapi_3 --to=swagger_2 openApi/dashboard-api-docs.json > openApi/generated/dashboard-swagger20.json && node openApi/scripts/api-b4f-dashboard_fixPreGen.js && node ./node_modules/@pagopa/selfcare-common-frontend/utils/fixSwagger20ArraySchemaDef.js openApi/generated/dashboard-swagger20.json && gen-api-models --api-spec openApi/generated/dashboard-swagger20.json --out-dir src/api/generated/b4f-dashboard --no-strict --request-types --response-decoders --client && node openApi/scripts/api-b4f-dashboard_fixPostGen.js"
   },
   "eslintConfig": {
     "extends": [

--- a/src/api/DashboardApiClient.ts
+++ b/src/api/DashboardApiClient.ts
@@ -8,7 +8,6 @@ import { createClient, WithDefaultsT } from './generated/b4f-dashboard/client';
 import { InstitutionResource } from './generated/b4f-dashboard/InstitutionResource';
 import { ProductsResource } from './generated/b4f-dashboard/ProductsResource';
 import { ProductRoleMappingsResource } from './generated/b4f-dashboard/ProductRoleMappingsResource';
-import { IdentityTokenResource } from './generated/b4f-dashboard/IdentityTokenResource';
 
 const withBearerAndPartyId: WithDefaultsT<'bearerAuth'> = (wrappedOperation) => (params: any) => {
   const token = storageTokenOps.read();
@@ -64,12 +63,12 @@ export const DashboardApi = {
     return extractResponse(result, 200, onRedirectToLogin);
   },
 
-  getTokenExchange: async (
+  getBackOfficeUrl: async (
     institutionId: string,
     productId: string,
     environment?: string
-  ): Promise<IdentityTokenResource> => {
-    const result = await apiClient.exchangeUsingGET({
+  ): Promise<string> => {
+    const result = await apiClient.retrieveProductBackofficeUsingGET({
       productId,
       institutionId,
       environment,

--- a/src/hooks/__tests__/useTokenExchange.test.tsx
+++ b/src/hooks/__tests__/useTokenExchange.test.tsx
@@ -26,35 +26,29 @@ afterAll(() => {
 
 jest.mock('../../services/tokenExchangeService');
 
-let retrieveTokenExchangeSpy;
+let retrieveBackOfficeUrlSpy;
 
 beforeEach(() => {
-  retrieveTokenExchangeSpy = jest.spyOn(
+  retrieveBackOfficeUrlSpy = jest.spyOn(
     require('../../services/tokenExchangeService'),
-    'retrieveTokenExchange'
+    'retrieveBackOfficeUrl'
   );
 });
 
 test('validateUrlBO', () => {
-  expect(validateUrlBO('https://hostname/path<IdentityToken>')).toBe('hostname');
-  expect(validateUrlBO('http://hostname/path<IdentityToken>')).toBe('hostname');
+  expect(validateUrlBO('https://hostname/path?id=<IdentityToken>')).toBe('hostname');
+  expect(validateUrlBO('http://hostname/path?id=<IdentityToken>')).toBe('hostname');
 
-  const wrongProtocolError = validateUrlBO('wrongprotocolhttp://hostname/path<IdentityToken>');
+  const wrongProtocolError = validateUrlBO('wrongprotocolhttp://hostname/path?id=<IdentityToken>');
   expect(wrongProtocolError instanceof Error).toBeTruthy();
   expect((wrongProtocolError as Error).message).toBe(
-    'Cannot extract hostname from URL: wrongprotocolhttp://hostname/path<IdentityToken>'
+    'Cannot extract hostname from URL: wrongprotocolhttp://hostname/path?id=<IdentityToken>'
   );
 
-  const wrongUrlError = validateUrlBO('wrongUrl/<IdentityToken>');
+  const wrongUrlError = validateUrlBO('wrongUrl/?id=<IdentityToken>');
   expect(wrongUrlError instanceof Error).toBeTruthy();
   expect((wrongUrlError as Error).message).toBe(
-    'Cannot extract hostname from URL: wrongUrl/<IdentityToken>'
-  );
-
-  const missingTokenPlaceholderError = validateUrlBO('https://hostname/path');
-  expect(missingTokenPlaceholderError instanceof Error).toBeTruthy();
-  expect((missingTokenPlaceholderError as Error).message).toBe(
-    "URL doesn't contain token placeholder <IdentityToken>: https://hostname/path"
+    'Cannot extract hostname from URL: wrongUrl/?id=<IdentityToken>'
   );
 });
 
@@ -88,19 +82,19 @@ describe('useTokenExchange', () => {
     expect(store.getState().appState.errors.length).toBe(1);
     expect(store.getState().appState.errors[0].onRetry).toBeUndefined();
 
-    expect(retrieveTokenExchangeSpy).toBeCalledTimes(0);
+    expect(retrieveBackOfficeUrlSpy).toBeCalledTimes(0);
   });
 
   test('test redirect', async () => {
-    const store = renderApp('https://hostname/path#<IdentityToken>');
+    const store = renderApp('https://hostname/path?id=<IdentityToken>');
     expect(store.getState().appState.errors.length).toBe(0);
     await waitFor(() => expect(store.getState().appState.loading.result).toBeFalsy());
 
-    expect(retrieveTokenExchangeSpy).toBeCalledTimes(1);
-    expect(retrieveTokenExchangeSpy).toBeCalledWith(expectedParty, expectedProduct);
+    expect(retrieveBackOfficeUrlSpy).toBeCalledTimes(1);
+    expect(retrieveBackOfficeUrlSpy).toBeCalledWith(expectedParty, expectedProduct);
 
     await waitFor(() =>
-      expect(mockedLocation.assign).toBeCalledWith('https://hostname/path#DUMMYTOKEN')
+      expect(mockedLocation.assign).toBeCalledWith('https://hostname/path?id=DUMMYTOKEN')
     );
   });
 });

--- a/src/hooks/useTokenExchange.ts
+++ b/src/hooks/useTokenExchange.ts
@@ -3,10 +3,9 @@ import useErrorDispatcher from '@pagopa/selfcare-common-frontend/hooks/useErrorD
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { LOADING_TASK_TOKEN_EXCHANGE } from '../utils/constants';
 import { Product } from '../model/Product';
-import { retrieveTokenExchange } from '../services/tokenExchangeService';
+import { retrieveBackOfficeUrl } from '../services/tokenExchangeService';
 import { Party } from '../model/Party';
 
-const tokenPlaceholder = '<IdentityToken>';
 const hostnameRegexp = /^(?:https?:\/\/)([-.a-zA-Z0-9_]+)/;
 
 export const useTokenExchange = () => {
@@ -37,8 +36,8 @@ export const useTokenExchange = () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     selectedEnvironment
-      ? retrieveTokenExchange(selectedParty, product, selectedEnvironment)
-          .then((t) => {
+      ? retrieveBackOfficeUrl(selectedParty, product, selectedEnvironment)
+          .then((url) => {
             setLoading(true);
             trackEvent(
               'DASHBOARD_OPEN_PRODUCT',
@@ -48,10 +47,7 @@ export const useTokenExchange = () => {
                 product_role: product.userRole,
                 target: 'prod',
               },
-              () =>
-                selectedEnvironmentUrl
-                  ? window.location.assign(selectedEnvironmentUrl.replace(tokenPlaceholder, t))
-                  : undefined
+              () => window.location.assign(url)
             );
           })
           .catch((error) =>
@@ -64,8 +60,8 @@ export const useTokenExchange = () => {
             })
           )
           .finally(() => setLoading(false))
-      : retrieveTokenExchange(selectedParty, product)
-          .then((t) => {
+      : retrieveBackOfficeUrl(selectedParty, product)
+          .then((url) => {
             setLoading(true);
             trackEvent(
               'DASHBOARD_OPEN_PRODUCT',
@@ -75,7 +71,7 @@ export const useTokenExchange = () => {
                 product_role: product.userRole,
                 target: selectedEnvironment,
               },
-              () => window.location.assign(product.urlBO.replace(tokenPlaceholder, t))
+              () => window.location.assign(url)
             );
           })
           .catch((error) =>
@@ -94,15 +90,10 @@ export const useTokenExchange = () => {
 };
 
 export const validateUrlBO = (url: string): string | Error => {
-  if (url?.indexOf(tokenPlaceholder) === -1) {
-    return new Error(`URL doesn't contain token placeholder ${tokenPlaceholder}: ${url}`);
-  }
-
   const hostname = hostnameFromUrl(url);
   if (!hostname) {
     return new Error(`Cannot extract hostname from URL: ${url}`);
   }
-
   return hostname;
 };
 

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/__tests__/ActiveProductCard.test.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/__tests__/ActiveProductCard.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from '../../../../../../redux/store';
-import { retrieveTokenExchange } from '../../../../../../services/tokenExchangeService';
+import { retrieveBackOfficeUrl } from '../../../../../../services/tokenExchangeService';
 import { mockedParties } from '../../../../../../services/__mocks__/partyService';
 import { mockedPartyProducts } from '../../../../../../services/__mocks__/productService';
 import './../../../../../../locale';
@@ -26,7 +26,7 @@ afterAll(() => {
 jest.mock('../../../../../../services/tokenExchangeService');
 
 beforeEach(() => {
-  jest.spyOn(require('../../../../../../services/tokenExchangeService'), 'retrieveTokenExchange');
+  jest.spyOn(require('../../../../../../services/tokenExchangeService'), 'retrieveBackOfficeUrl');
 });
 
 const mockedProduct = Object.assign({}, mockedPartyProducts[0]);
@@ -63,10 +63,8 @@ test('test render and behavior', async () => {
   fireEvent.click(button);
 
   await waitFor(() =>
-    expect(retrieveTokenExchange).toBeCalledWith(mockedParties[0], mockedProduct)
+    expect(retrieveBackOfficeUrl).toBeCalledWith(mockedParties[0], mockedProduct)
   );
 
-  expect(mockedLocation.assign).toBeCalledWith(
-    'https://io.selfcare.pagopa.it/path/acs?token=DUMMYTOKEN'
-  );
+  expect(mockedLocation.assign).toBeCalledWith('https://hostname/path?id=DUMMYTOKEN');
 });

--- a/src/services/__mocks__/tokenExchangeService.ts
+++ b/src/services/__mocks__/tokenExchangeService.ts
@@ -1,8 +1,8 @@
 import { Party } from '../../model/Party';
 import { Product } from '../../model/Product';
 
-export const retrieveTokenExchange = (
-  _hostname: string,
+export const retrieveBackOfficeUrl = (
   _selectedParty: Party,
-  _product: Product
-): Promise<string> => new Promise((resolve) => resolve('DUMMYTOKEN'));
+  _product: Product,
+  _environment: string
+): Promise<string> => new Promise((resolve) => resolve('https://hostname/path?id=DUMMYTOKEN'));

--- a/src/services/__tests__/tokenExchangeService.test.ts
+++ b/src/services/__tests__/tokenExchangeService.test.ts
@@ -1,23 +1,17 @@
 import { mockedParties } from '../__mocks__/partyService';
-import { DashboardApi } from '../../api/DashboardApiClient';
-import { retrieveTokenExchange } from '../tokenExchangeService';
+import { retrieveBackOfficeUrl } from '../tokenExchangeService';
 import { mockedPartyProducts } from '../__mocks__/productService';
 
-jest.mock('../../api/DashboardApiClient');
+jest.mock('../tokenExchangeService');
 
 beforeEach(() => {
-  jest.spyOn(DashboardApi, 'getTokenExchange');
+  jest.spyOn(require('../tokenExchangeService'), 'retrieveBackOfficeUrl');
 });
 
 test('Test retrieveTokenExchange', async () => {
-  const token = await retrieveTokenExchange(mockedParties[0], mockedPartyProducts[0]);
+  const url = await retrieveBackOfficeUrl(mockedParties[0], mockedPartyProducts[0]);
 
-  expect(token).toBe('DUMMYTOKEN');
+  expect(url).toBe('https://hostname/path?id=DUMMYTOKEN');
 
-  expect(DashboardApi.getTokenExchange).toBeCalledTimes(1);
-  expect(DashboardApi.getTokenExchange).toBeCalledWith(
-    mockedParties[0].partyId,
-    mockedPartyProducts[0].id,
-    undefined
-  );
+  expect(retrieveBackOfficeUrl).toBeCalledTimes(1);
 });

--- a/src/services/tokenExchangeService.ts
+++ b/src/services/tokenExchangeService.ts
@@ -2,11 +2,8 @@ import { DashboardApi } from '../api/DashboardApiClient';
 import { Party } from '../model/Party';
 import { Product } from '../model/Product';
 
-export const retrieveTokenExchange = (
+export const retrieveBackOfficeUrl = (
   selectedParty: Party,
   product: Product,
   environment?: string
-): Promise<string> =>
-  DashboardApi.getTokenExchange(selectedParty.partyId, product.id, environment).then(
-    (r) => r.token
-  );
+): Promise<string> => DashboardApi.getBackOfficeUrl(selectedParty.partyId, product.id, environment);


### PR DESCRIPTION


* SELC-1648 Swap to API which retrieves the entire url + consequent adaptation of the names of the methods to make them more speaking

* Fixed generated problem

* Fixed generated problem

* SELC-1648 Fixed unitTests

* temp commit

Co-authored-by: loremedda <lorenzo.medda@nttdata.com>