### PR TITLE
Selecting the submenu does not also select other sidenav items

### DIFF
--- a/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
+++ b/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
@@ -48,7 +48,8 @@ export default function DashboardSideMenu({
   });
 
   const isOVerviewSelected = window.location.pathname === overviewPath;
-  const isRoleSelected = window.location.pathname.startsWith(usersPath);
+  const isUserSelected = window.location.pathname.startsWith(usersPath);
+  const isDelegateSelected = window.location.pathname.startsWith(delegatesPath);
   const isGroupSelected = window.location.pathname.startsWith(groupsPath);
 
   return (
@@ -61,6 +62,7 @@ export default function DashboardSideMenu({
               onExit(() => history.push(party.partyId ? overviewPath : overviewRoute))
             }
             isSelected={isOVerviewSelected}
+            isSubMenuSelected={isDelegateSelected}
             icon={DashboardCustomize}
             subMenuVisible={!!isDelegateSectionVisible}
             subMenuIcon={AssignmentIcon}
@@ -73,7 +75,7 @@ export default function DashboardSideMenu({
             <DashboardSidenavItem
               title={t('overview.sideMenu.institutionManagement.referents.title')}
               handleClick={() => onExit(() => history.push(party.partyId ? usersPath : usersRoute))}
-              isSelected={isRoleSelected}
+              isSelected={isUserSelected}
               icon={PeopleAlt}
               subMenuVisible={false}
             />

--- a/src/pages/dashboard/components/dashboardSideMenu/DashboardSidenavItem.tsx
+++ b/src/pages/dashboard/components/dashboardSideMenu/DashboardSidenavItem.tsx
@@ -6,6 +6,7 @@ type Props = {
   handleClick: () => void;
   title: string;
   isSelected?: boolean;
+  isSubMenuSelected?: boolean;
   icon: SvgIconComponent;
   subMenuVisible: boolean;
   subMenuIcon?: SvgIconComponent;
@@ -18,6 +19,7 @@ export default function DashboardSidenavItem({
   handleClickSubMenu,
   title,
   isSelected,
+  isSubMenuSelected,
   icon,
   subMenuVisible,
   subMenuIcon,
@@ -25,7 +27,7 @@ export default function DashboardSidenavItem({
 }: Props) {
   const [open, setOpen] = React.useState(true);
 
-  const handleHopen = () => {
+  const handleOpen = () => {
     setOpen(!open);
   };
 
@@ -36,7 +38,7 @@ export default function DashboardSidenavItem({
         selected={isSelected}
         onClick={() => {
           handleClick();
-          handleHopen();
+          handleOpen();
         }}
         sx={{
           height: '100%',
@@ -55,7 +57,7 @@ export default function DashboardSidenavItem({
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
             <ListItemButton
-              selected={!isSelected}
+              selected={isSubMenuSelected ?? false}
               sx={{ pl: 4, height: '100%', maxWidth: 360, backgroundColor: 'background.paper' }}
               onClick={() => {
                 handleClickSubMenu();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
When clicking on a sidebar item other than overview, the selection also affected the submenu if it was open

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Selecting the submenu does not also select other sidenav items

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.