### PR TITLE
SELC-2849 Add filter and graphic changes in dashboard

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -199,6 +199,7 @@ export default {
         productSelectLabel: 'Prodotto',
         buttonLabel: 'Filtra',
         allProductsLabel: 'Tutti  i prodotti',
+        resetFilter: 'Annulla filtri',
       },
     },
     genericError: {

--- a/src/pages/dashboardTechnologyPartnerPage/DashboardTableContainer.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/DashboardTableContainer.tsx
@@ -1,8 +1,8 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { Box } from '@mui/system';
+import { Box, Divider } from '@mui/material';
+import { ButtonNaked } from '@pagopa/mui-italia';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ButtonNaked } from '@pagopa/mui-italia';
 import { DelegationResource } from '../../api/generated/b4f-dashboard/DelegationResource';
 import DashboardTablePT from './DashboardTablePT';
 
@@ -27,24 +27,20 @@ export default function DashboardTableContainer({ filteredArray }: Props) {
     >
       <DashboardTablePT filteredArray={filteredArray} />
       {!expandMore && areMoreThen5Elemnts && (
-        <Box
-          width={'100%'}
-          sx={{ backgroundColor: 'white' }}
-          mt={'1px'}
-          p={2}
-          display="flex"
-          justifyContent={'center'}
-        >
-          <ButtonNaked
-            onClick={() => setExpandMore(true)}
-            endIcon={<KeyboardArrowDownIcon />}
-            weight="default"
-            size="large"
-            color="primary"
-          >
-            {t('overview.ptPage.bodyPtTable.showMoreButtonLabel')}
-          </ButtonNaked>
-        </Box>
+        <>
+          <Divider color="divider" />
+          <Box sx={{ backgroundColor: 'white' }} p="4px" display="flex" justifyContent="center">
+            <ButtonNaked
+              onClick={() => setExpandMore(true)}
+              endIcon={<KeyboardArrowDownIcon />}
+              weight="default"
+              size="large"
+              color="primary"
+            >
+              {t('overview.ptPage.bodyPtTable.showMoreButtonLabel')}
+            </ButtonNaked>
+          </Box>
+        </>
       )}
     </Box>
   );

--- a/src/pages/dashboardTechnologyPartnerPage/DashboardTablePT.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/DashboardTablePT.tsx
@@ -1,25 +1,25 @@
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import {
-  TableContainer,
+  Button,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
-  Typography,
-  IconButton,
   TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Button,
+  Typography,
 } from '@mui/material';
+import { ButtonNaked } from '@pagopa/mui-italia';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import Paper from '@mui/material/Paper';
-import { Box } from '@mui/system';
 import { DelegationResource } from '../../api/generated/b4f-dashboard/DelegationResource';
 
 type Props = {
@@ -88,23 +88,35 @@ export default function DashboardTablePT({ filteredArray }: Props) {
     setSearchResults(filteredResults);
   };
 
+  const hasBeenDelegated = filteredArray && filteredArray.length > 0;
+
+  const handleResetFilter = () => {
+    setSearchTerm('');
+    setSelectedProduct('All');
+    setSearchResults(filteredArray);
+  };
+
   return (
     <>
-      {/* Filter */}
-      {/* TODO: the filters and the results have been hidden if there are no elements because the layout refactor must be finished. After the refactor show filters disabled if there are no items, as requested. */}
-      {filteredArray && filteredArray.length > 0 && (
-        <Box my={2}>
+      <Grid container spacing={1}>
+        <Grid item xs={5}>
           <TextField
             label={t('overview.ptPage.filterTechPartner.textfieldLabel')}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
+            disabled={!hasBeenDelegated}
+            fullWidth
+            size="small"
           />
-          <FormControl>
+        </Grid>
+        <Grid item xs={5}>
+          <FormControl fullWidth={true} size="small">
             <InputLabel> {t('overview.ptPage.filterTechPartner.productSelectLabel')}</InputLabel>
             <Select
-              sx={{ width: '200px' }}
               value={selectedProduct}
               onChange={(e) => setSelectedProduct(e.target.value as string)}
+              disabled={!hasBeenDelegated}
+              label={t('overview.ptPage.filterTechPartner.productSelectLabel')}
             >
               <MenuItem value="All">
                 {t('overview.ptPage.filterTechPartner.allProductsLabel')}
@@ -113,92 +125,106 @@ export default function DashboardTablePT({ filteredArray }: Props) {
               <MenuItem value="prod-pagopa">{codeToLabelProduct('prod-pagopa')}</MenuItem>
             </Select>
           </FormControl>
-
-          <Button variant="contained" onClick={handleSearch}>
+        </Grid>
+        <Grid item xs={1}>
+          <Button
+            variant="outlined"
+            onClick={handleSearch}
+            disabled={!hasBeenDelegated}
+            size="small"
+          >
             {t('overview.ptPage.filterTechPartner.buttonLabel')}
           </Button>
-        </Box>
+        </Grid>
+        <Grid item xs={1}>
+          <ButtonNaked
+            onClick={handleResetFilter}
+            color="primary"
+            variant="text"
+            disabled={!hasBeenDelegated}
+            sx={{ textAlign: 'center' }}
+            component="button"
+          >
+            {t('overview.ptPage.filterTechPartner.resetFilter')}
+          </ButtonNaked>
+        </Grid>
+      </Grid>
+      {!hasBeenDelegated ? null : (
+        <TableContainer sx={{ height: '100%', overflow: 'hidden' }}>
+          <Table sx={{ minWidth: 'auto', height: '100%' }} aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                <TableCell sortDirection={'asc'}>
+                  {t('overview.ptPage.headerPtTableLabels.party')}
+                  <IconButton
+                    style={{ backgroundColor: 'transparent', padding: '0 8px' }}
+                    disableRipple
+                    onClick={() => handleSort('institutionName')}
+                  >
+                    {orderBy === 'institutionName' ? (
+                      order === 'asc' ? (
+                        <ArrowUpwardIcon fontSize="small" />
+                      ) : (
+                        <ArrowDownwardIcon fontSize="small" />
+                      )
+                    ) : (
+                      <ArrowUpwardIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                </TableCell>
+                <TableCell>{t('overview.ptPage.headerPtTableLabels.product')}</TableCell>
+                <TableCell></TableCell>
+                <TableCell></TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody sx={{ backgroundColor: 'background.paper' }}>
+              {searchResults && filteredArray.length > 0
+                ? searchResults.map((item) => (
+                    <TableRow key={item.institutionName}>
+                      <TableCell>
+                        <Typography sx={{ fontWeight: '700' }}>{item.institutionName}</Typography>
+                      </TableCell>
+                      <TableCell>{codeToLabelProduct(item.productId as string)}</TableCell>
+                      <TableCell width={'20%'}>
+                        <Typography>-</Typography>
+                      </TableCell>
+                      <TableCell width={'20%'}>
+                        <Typography>-</Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography width={'10%'}></Typography>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : sortedData.map((tl, index) => (
+                    <TableRow key={index}>
+                      <TableCell width={'25%'}>
+                        <Typography
+                          sx={{
+                            fontWeight: 'fontWeightBold',
+                          }}
+                        >
+                          {tl.institutionName}
+                        </Typography>
+                      </TableCell>
+                      <TableCell width={'25%'}>
+                        <Typography sx={{ cursor: 'pointer' }}>
+                          {codeToLabelProduct(tl.productId as string)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell width={'25%'}>
+                        <Typography sx={{ cursor: 'pointer' }}>-</Typography>
+                      </TableCell>
+                      <TableCell width={'25%'}>
+                        <Typography sx={{ cursor: 'pointer' }}>-</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       )}
-      <TableContainer component={Paper} sx={{ height: '100%', overflow: 'hidden' }}>
-        <Table sx={{ minWidth: 'auto', height: '100%' }} aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <TableCell sortDirection={'asc'}>
-                {t('overview.ptPage.headerPtTableLabels.party')}
-                <IconButton
-                  style={{ backgroundColor: 'transparent', padding: '0 8px' }}
-                  disableRipple
-                  onClick={() => handleSort('institutionName')}
-                >
-                  {orderBy === 'institutionName' ? (
-                    order === 'asc' ? (
-                      <ArrowUpwardIcon fontSize="small" />
-                    ) : (
-                      <ArrowDownwardIcon fontSize="small" />
-                    )
-                  ) : (
-                    <ArrowUpwardIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </TableCell>
-              <TableCell>
-                {t('overview.ptPage.headerPtTableLabels.product')}
-                <IconButton
-                  style={{ backgroundColor: 'transparent', padding: '0 8px' }}
-                  disableRipple
-                  onClick={() => handleSort('productId')}
-                >
-                  {orderBy === 'productId' ? (
-                    order === 'asc' ? (
-                      <ArrowUpwardIcon fontSize="small" />
-                    ) : (
-                      <ArrowDownwardIcon fontSize="small" />
-                    )
-                  ) : (
-                    <ArrowDownwardIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </TableCell>
-              <TableCell></TableCell>
-              <TableCell></TableCell>
-              <TableCell></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {searchResults && filteredArray.length > 0
-              ? searchResults.map((item) => (
-                  <TableRow key={item.institutionName}>
-                    <TableCell>{item.institutionName}</TableCell>
-                    <TableCell>{codeToLabelProduct(item.productId as string)}</TableCell>
-                  </TableRow>
-                ))
-              : sortedData.map((tl, index) => (
-                  <TableRow key={index}>
-                    <TableCell width={'25%'}>
-                      <Typography
-                        sx={{
-                          fontWeight: 'fontWeightBold',
-                        }}
-                      >
-                        {tl.institutionName}
-                      </Typography>
-                    </TableCell>
-                    <TableCell width={'25%'}>
-                      <Typography sx={{ cursor: 'pointer' }}>
-                        {codeToLabelProduct(tl.productId as string)}
-                      </Typography>
-                    </TableCell>
-                    <TableCell width={'25%'}>
-                      <Typography sx={{ cursor: 'pointer' }}>-</Typography>
-                    </TableCell>
-                    <TableCell width={'25%'}>
-                      <Typography sx={{ cursor: 'pointer' }}>-</Typography>
-                    </TableCell>
-                  </TableRow>
-                ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
     </>
   );
 }

--- a/src/pages/dashboardTechnologyPartnerPage/TechnologyPartnerTable.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/TechnologyPartnerTable.tsx
@@ -59,11 +59,9 @@ export default function TechnologyPartnerTable({ party }: Props) {
 
   return !loading ? (
     <>
-      {filteredArray && filteredArray.length > 0 ? (
-        // Table and Filter
-        <DashboardTableContainer filteredArray={filteredArray} />
-      ) : (
-        // empty state
+      <DashboardTableContainer filteredArray={filteredArray} />
+
+      {filteredArray && filteredArray.length === 0 && (
         <Box
           width={'100%'}
           p={2}


### PR DESCRIPTION
#### List of Changes

Add missing filters table head in case of getTechnologyPartnersList api return empty
Add missing reset filters button from as in figma
Add missing divider above "See more" button

#### Motivation and Context

The page and the design on figma were different. Need to make changes to follow figma design.

#### How Has This Been Tested?

Run application locally with mocked api getTechnologyPartnersList  to return or not a list

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.