### PR TITLE
SELC-2970_hide delegation in case the product role is not admin

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -101,20 +101,15 @@ const Dashboard = () => {
       [products, party]
     ) ?? [];
 
-  const isAuthorizedAndAdminProducts: Array<Product> =
-    useMemo(
-      () =>
-        products?.filter((p) =>
-          party?.products.some(
-            (partyProduct) =>
-              partyProduct.productId === p.id &&
-              partyProduct.authorized &&
-              (partyProduct.productId === 'prod-io' || partyProduct.productId === 'prod-pagopa') &&
-              partyProduct.userRole === 'ADMIN'
-          )
-        ),
-      [products, party]
-    ) ?? [];
+  const delegableProducts: Array<Product> = activeProducts.filter((p) =>
+    party?.products.some(
+      (partyProduct) =>
+        partyProduct.authorized &&
+        (partyProduct.productId === 'prod-io' || partyProduct.productId === 'prod-pagopa') &&
+        partyProduct.userRole === 'ADMIN' &&
+        p.delegable
+    )
+  );
 
   const productsMap: ProductsMap =
     useMemo(() => buildProductsMap(products ?? []), [products]) ?? [];
@@ -123,14 +118,8 @@ const Dashboard = () => {
   const canSeeSection = parties?.find((p) => p.partyId === party?.partyId)?.userRole === 'ADMIN';
   const isPtSectionVisible = party?.institutionType === 'PT' && canSeeSection;
 
-  const delegableProducts = activeProducts.filter((p) => p.delegable === true);
-
   const isDelegateSectionVisible =
-    ENV.DELEGATIONS.ENABLE &&
-    delegableProducts &&
-    delegableProducts.length > 0 &&
-    canSeeSection &&
-    isAuthorizedAndAdminProducts.length > 0;
+    ENV.DELEGATIONS.ENABLE && delegableProducts.length > 0 && canSeeSection;
 
   return party && products ? (
     <Grid container item xs={12} sx={{ backgroundColor: 'background.paper' }}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -110,6 +110,16 @@ const Dashboard = () => {
       [products, party]
     ) ?? [];
 
+  const isAdminOnProduct =
+    useMemo(
+      () =>
+        party?.products.some(
+          (p) =>
+            (p.productId === 'prod-io' || p.productId === 'prod-pagopa') && p.userRole === 'ADMIN'
+        ),
+      [products, party]
+    ) ?? false;
+
   const productsMap: ProductsMap =
     useMemo(() => buildProductsMap(products ?? []), [products]) ?? [];
 
@@ -120,7 +130,12 @@ const Dashboard = () => {
   const delegableProducts = activeProducts.filter((p) => p.delegable === true);
 
   const isDelegateSectionVisible =
-    ENV.DELEGATIONS.ENABLE && delegableProducts && delegableProducts.length > 0 && canSeeSection && authorizedProducts.length > 0;
+    ENV.DELEGATIONS.ENABLE &&
+    delegableProducts &&
+    delegableProducts.length > 0 &&
+    canSeeSection &&
+    authorizedProducts.length > 0 &&
+    isAdminOnProduct;
 
   return party && products ? (
     <Grid container item xs={12} sx={{ backgroundColor: 'background.paper' }}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -101,24 +101,20 @@ const Dashboard = () => {
       [products, party]
     ) ?? [];
 
-  const authorizedProducts: Array<Product> =
+  const isAuthorizedAndAdminProducts: Array<Product> =
     useMemo(
       () =>
         products?.filter((p) =>
-          party?.products.some((ap) => ap.productId === p.id && ap.authorized)
+          party?.products.some(
+            (partyProduct) =>
+              partyProduct.productId === p.id &&
+              partyProduct.authorized &&
+              (partyProduct.productId === 'prod-io' || partyProduct.productId === 'prod-pagopa') &&
+              partyProduct.userRole === 'ADMIN'
+          )
         ),
       [products, party]
     ) ?? [];
-
-  const isAdminOnProduct =
-    useMemo(
-      () =>
-        party?.products.some(
-          (p) =>
-            (p.productId === 'prod-io' || p.productId === 'prod-pagopa') && p.userRole === 'ADMIN'
-        ),
-      [products, party]
-    ) ?? false;
 
   const productsMap: ProductsMap =
     useMemo(() => buildProductsMap(products ?? []), [products]) ?? [];
@@ -134,8 +130,7 @@ const Dashboard = () => {
     delegableProducts &&
     delegableProducts.length > 0 &&
     canSeeSection &&
-    authorizedProducts.length > 0 &&
-    isAdminOnProduct;
+    isAuthorizedAndAdminProducts.length > 0;
 
   return party && products ? (
     <Grid container item xs={12} sx={{ backgroundColor: 'background.paper' }}>

--- a/src/pages/dashboardOverview/DashboardOverview.tsx
+++ b/src/pages/dashboardOverview/DashboardOverview.tsx
@@ -35,12 +35,13 @@ const DashboardOverview = ({ party, products }: Props) => {
   ) ?? [party.products];
 
   const delegableProducts = activeProducts.find(
-    (p) => p.productId === 'prod-io' || p.productId === 'prod-pagopa'
+    (p) => (p.productId === 'prod-io' || p.productId === 'prod-pagopa') && p.userRole === 'ADMIN'
   );
 
   const isDelegable = ENV.DELEGATIONS.ENABLE && isAdmin;
 
-  const hasPartyDelegableProducts = delegableProducts &&  party.institutionType !== 'PT' && isDelegable;
+  const hasPartyDelegableProducts =
+    delegableProducts && party.institutionType !== 'PT' && isDelegable;
 
   const showInfoBanner = party.institutionType === 'PA';
 

--- a/src/pages/dashboardOverview/DashboardOverview.tsx
+++ b/src/pages/dashboardOverview/DashboardOverview.tsx
@@ -34,14 +34,14 @@ const DashboardOverview = ({ party, products }: Props) => {
     [party.products]
   ) ?? [party.products];
 
-  const delegableProducts = activeProducts.find(
+  const delegableProduct = activeProducts.find(
     (p) => (p.productId === 'prod-io' || p.productId === 'prod-pagopa') && p.userRole === 'ADMIN'
   );
 
   const isDelegable = ENV.DELEGATIONS.ENABLE && isAdmin;
 
   const hasPartyDelegableProducts =
-    delegableProducts && party.institutionType !== 'PT' && isDelegable;
+    delegableProduct && party.institutionType !== 'PT' && isDelegable;
 
   const showInfoBanner = party.institutionType === 'PA';
 

--- a/src/pages/dashboardOverview/DashboardOverview.tsx
+++ b/src/pages/dashboardOverview/DashboardOverview.tsx
@@ -20,7 +20,7 @@ type Props = {
 const DashboardOverview = ({ party, products }: Props) => {
   const isAdmin = party.userRole === 'ADMIN';
 
-  const activeProducts: Array<OnboardedProduct> = useMemo(
+  const manageablePartyProducts: Array<OnboardedProduct> = useMemo(
     () =>
       party.products?.filter((us) =>
         products.some(
@@ -28,20 +28,20 @@ const DashboardOverview = ({ party, products }: Props) => {
             us.productId === p.id &&
             us.productOnBoardingStatus === 'ACTIVE' &&
             us.authorized === true &&
+            us.userRole === 'ADMIN' &&
             p.delegable
         )
       ),
     [party.products]
   ) ?? [party.products];
 
-  const delegableProduct = activeProducts.find(
-    (p) => (p.productId === 'prod-io' || p.productId === 'prod-pagopa') && p.userRole === 'ADMIN'
+  const delegableProduct = manageablePartyProducts.find(
+    (p) => p.productId === 'prod-io' || p.productId === 'prod-pagopa'
   );
 
-  const isDelegable = ENV.DELEGATIONS.ENABLE && isAdmin;
+  const isDelegable = ENV.DELEGATIONS.ENABLE && isAdmin && delegableProduct;
 
-  const hasPartyDelegableProducts =
-    delegableProduct && party.institutionType !== 'PT' && isDelegable;
+  const hasPartyDelegableProducts = party.institutionType !== 'PT' && isDelegable;
 
   const showInfoBanner = party.institutionType === 'PA';
 


### PR DESCRIPTION
#### List of Changes

SELC-2970  fix

#### Motivation and Context

When the role in the product prod-io or prod-pagopa was operator and on another product was admin delegation section was visible

#### How Has This Been Tested?

test locally with mock calls

#### Screenshots (if appropriate):

#### Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.