### PR TITLE
SELC-3034 + unit test delegation page

### DIFF
--- a/src/pages/dashboardDelegations/__test__/DashboardDelegationsPage.test.tsx
+++ b/src/pages/dashboardDelegations/__test__/DashboardDelegationsPage.test.tsx
@@ -1,0 +1,74 @@
+import { act, cleanup, fireEvent, screen } from '@testing-library/react';
+import { mockedParties } from '../../../services/__mocks__/partyService';
+import { mockedPartyProducts } from '../../../services/__mocks__/productService';
+import { renderWithProviders } from '../../../utils/test-utils';
+import DashboardDelegationsPage from '../DashboardDelegationsPage';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DashboardDelegationsPage', () => {
+  test('Should render generic Error message when DashboardDelegationsPage prop isDelegateSectionVisible is undefined', async () => {
+    renderWithProviders(
+      <DashboardDelegationsPage
+        party={{
+          partyId: '',
+          products: [],
+          externalId: undefined,
+          originId: undefined,
+          origin: undefined,
+          description: '',
+          digitalAddress: undefined,
+          category: undefined,
+          urlLogo: undefined,
+          fiscalCode: undefined,
+          registeredOffice: '',
+          zipCode: '',
+          typology: '',
+          institutionType: undefined,
+          recipientCode: undefined,
+          geographicTaxonomies: [],
+          vatNumberGroup: undefined,
+          supportEmail: undefined,
+          vatNumber: undefined,
+          subunitCode: undefined,
+          subunitType: undefined,
+          aooParentCode: undefined,
+          parentDescription: undefined,
+          userRole: undefined,
+          status: undefined,
+        }}
+        delegableProducts={[]}
+      />
+    );
+    const ErrorMessage = await screen.findByText('Errore');
+    expect(ErrorMessage).toBeInTheDocument();
+    
+    const closeBtn = screen.getByText('Chiudi');
+    fireEvent.click(closeBtn);
+  });
+
+  test('Should render component DashboardDelegationsPage with populated props and isDelegateSectionVisible is true', async () => {
+    const mockedGsp = mockedParties[11];
+    const { history } = renderWithProviders(
+      <DashboardDelegationsPage
+        party={mockedGsp}
+        delegableProducts={mockedPartyProducts}
+        isDelegateSectionVisible
+      />
+    );
+    // test back button
+    const backBtn = await screen.findByText('Indietro');
+    const goBackMock = jest.spyOn(history, 'goBack');
+
+    await act(async () => {
+      fireEvent.click(backBtn);
+    });
+
+    // Assert that history.goBack() was called
+    expect(goBackMock).toHaveBeenCalled();
+
+    goBackMock.mockRestore();
+  });
+});

--- a/src/pages/dashboardOverview/__test__/DashboardOverview.test.tsx
+++ b/src/pages/dashboardOverview/__test__/DashboardOverview.test.tsx
@@ -1,13 +1,10 @@
 import { fireEvent, screen } from '@testing-library/react';
+import '../../../locale';
 import { mockedParties } from '../../../services/__mocks__/partyService';
 import { mockedPartyProducts } from '../../../services/__mocks__/productService';
 import { renderWithProviders } from '../../../utils/test-utils';
 import DashboardOverview from '../DashboardOverview';
-import '../../../locale';
 
-beforeEach(() => {
-  jest.spyOn(console, 'warn').mockImplementation(() => {});
-});
 
 test('should render component DashboardOverview with empty party', async () => {
   renderWithProviders(

--- a/src/pages/dashboardOverview/components/activeProductsSection/ActiveProductsSection.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/ActiveProductsSection.tsx
@@ -15,9 +15,10 @@ type Props = {
 export default function ActiveProductsSection({ party, products }: Props) {
   const { t } = useTranslation();
 
-  const prodInterop = party.products.find(
-    (p) => p.productId === 'prod-interop' && p.authorized === true
-  );
+  const prodInterop = party.products.find((p) => p.productId === 'prod-interop' && p.authorized);
+
+  const haveProdInteropAndEnvProduct =
+    prodInterop && party.products.find((p) => p.productId === 'prod-interop-coll' && p.authorized);
 
   return (
     <React.Fragment>
@@ -43,7 +44,7 @@ export default function ActiveProductsSection({ party, products }: Props) {
               key={product.productId}
               party={party}
               product={product}
-              haveProdInterop={!!prodInterop}
+              haveProdInteropAndEnvProduct={!!haveProdInteropAndEnvProduct}
               products={products}
             />
           ))}

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -12,14 +12,14 @@ import SessionModalInteropProduct from './SessionModalInteropProduct';
 type Props = {
   party: Party;
   product: OnboardedProduct;
-  haveProdInterop: boolean;
+  haveProdInteropAndEnvProduct: boolean;
   products: Array<Product>;
 };
 
 export default function ActiveProductCardContainer({
   party,
   product,
-  haveProdInterop,
+  haveProdInteropAndEnvProduct,
   products,
 }: Props) {
   const { t } = useTranslation();
@@ -43,9 +43,10 @@ export default function ActiveProductCardContainer({
           buttonLabel={t('overview.activeProducts.manageButton')}
           urlLogo={productOnboarded?.logo ?? ''}
           btnAction={() =>
-            haveProdInterop && productOnboarded && productOnboarded.id === 'prod-interop'
+            haveProdInteropAndEnvProduct && productOnboarded.id === 'prod-interop'
               ? setOpenCustomEnvInteropModal(true)
-              : productOnboarded?.backOfficeEnvironmentConfigurations
+              : productOnboarded?.backOfficeEnvironmentConfigurations &&
+                productOnboarded.id !== 'prod-interop'
               ? setOpenGenericEnvProductModal(true)
               : invokeProductBo(productOnboarded, party)
           }
@@ -70,7 +71,7 @@ export default function ActiveProductCardContainer({
         handleClose={() => {
           setOpenCustomEnvInteropModal(false);
         }}
-        prodInteropAndProdInteropColl={haveProdInterop}
+        prodInteropAndProdInteropColl={haveProdInteropAndEnvProduct}
         products={products}
         party={party}
       />

--- a/src/pages/dashboardTechnologyPartnerPage/__tests__/DashboardTablePT.test.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/__tests__/DashboardTablePT.test.tsx
@@ -45,7 +45,7 @@ test('test input field change and filter on click', async () => {
 
   // Find the input field by its label
   const inputField = screen.getByLabelText(
-    'overview.ptPage.filterTechPartner.textfieldLabel'
+    'Cerca per nome'
   ) as HTMLInputElement;
 
   // Simulate user typing "Broker 1"
@@ -55,7 +55,7 @@ test('test input field change and filter on click', async () => {
   expect(inputField.value).toBe('Broker 1');
 
   // Find and click the button
-  const FilterButton = screen.getByText('overview.ptPage.filterTechPartner.buttonLabel');
+  const FilterButton = screen.getByText('Filtra');
   fireEvent.click(FilterButton);
 
 });

--- a/src/services/__mocks__/partyService.ts
+++ b/src/services/__mocks__/partyService.ts
@@ -64,6 +64,12 @@ export const mockedBaseParties: Array<BaseParty> = [
     status: 'ACTIVE',
     userRole: 'ADMIN',
   },
+  {
+    partyId: '11',
+    description: 'Comune di Cernusco sul Naviglio',
+    status: 'ACTIVE',
+    userRole: 'ADMIN',
+  },
 ];
 
 export const mockedParties: Array<Party> = [
@@ -178,6 +184,7 @@ export const mockedParties: Array<Party> = [
     ],
     vatNumber: '111122211111',
     products: [
+      // Use case with one delegable product
       {
         productId: 'prod-io',
         authorized: true,
@@ -655,6 +662,80 @@ export const mockedParties: Array<Party> = [
         billing: {
           vatNumber: '66554328912',
           recipientCode: 'cccc',
+          publicServices: true,
+        },
+      },
+      // Use case with only prod-interop
+      {
+        productId: 'prod-interop',
+        authorized: true,
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+        userRole: 'ADMIN',
+        billing: {
+          vatNumber: '3395867495',
+          recipientCode: 'NBG455B',
+          publicServices: true,
+        },
+      },
+    ],
+    status: 'ACTIVE',
+    userRole: 'ADMIN',
+  },
+  {
+    description: 'Comune di Cernusco sul Naviglio',
+    urlLogo: 'image',
+    partyId: '11',
+    digitalAddress: 'comune.cernusco@pec.it',
+    fiscalCode: '76859430212',
+    category: 'Comuni e loro Consorzi e Associazioni',
+    registeredOffice: 'Piazza della Scala, 2',
+    zipCode: '20121',
+    typology: 'Pubblica Amministrazione',
+    externalId: '36',
+    originId: '46',
+    origin: 'IPA',
+    institutionType: 'PA',
+    recipientCode: 'CGDDS33A',
+    geographicTaxonomies: [
+      { code: '32356', desc: 'Milano - Comune' },
+      { code: '456723', desc: 'Carugate - Comune' },
+      { code: '665543', desc: 'Cernusco sul Naviglio - Comune' },
+    ], // Use case with three taxonomy
+    vatNumber: '34434356575',
+    supportEmail: '',
+    products: [
+      // Use case with two delegable products
+      {
+        productId: 'prod-io',
+        authorized: true,
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+        userRole: 'ADMIN',
+        billing: {
+          vatNumber: '81001510528',
+          recipientCode: 'BBGG34D',
+          publicServices: true,
+        },
+      },
+      {
+        productId: 'prod-pagopa',
+        authorized: true,
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+        userRole: 'ADMIN',
+        billing: {
+          vatNumber: '3334546566',
+          recipientCode: 'PBC945',
+          publicServices: true,
+        },
+      },
+      // Use case with only prod-interop-coll
+      {
+        productId: 'prod-interop-coll',
+        authorized: true,
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+        userRole: 'ADMIN',
+        billing: {
+          vatNumber: '3395867495',
+          recipientCode: 'NBG455B',
           publicServices: true,
         },
       },

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import './locale';


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Release in UAT of ticket 3034 for showing popup in interop product only when operating product and environment product are available, in opposite case redirect directly to product back-office + unit test delegation page

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Resolve the popup showed when a user is added only in interop operating product

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local with added mocks and with environment data api response
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.