### PR TITLE
SELC-3032 remove ability to hide delegation button in side menu

### DIFF
--- a/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
+++ b/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
@@ -66,27 +66,30 @@ export default function DashboardSideMenu({
               onExit(() => history.push(party.partyId ? overviewPath : overviewRoute))
             }
             isSelected={isOVerviewSelected}
-            isSubMenuSelected={isDelegateSelected}
             icon={DashboardCustomize}
-            subMenuVisible={!!isDelegateSectionVisible}
-            subMenuIcon={AssignmentIcon}
-            subMenuTitle={t('overview.sideMenu.institutionManagement.overview.subMenu.title')}
-            handleClickSubMenu={() =>
-              onExit(() => history.push(party.partyId ? delegatesPath : delegatesRoute))
-            }
             isPtPageVisible={party?.institutionType === 'PT'}
             ptIcon={DnsIcon}
             ptTitle={t('overview.ptPage.title')}
             isPtSelected={isPtSelected}
             handleClickPtPage={() => onExit(() => history.push(party.partyId ? ptPath : ptRoute))}
           />
+          {isDelegateSectionVisible && (
+            <DashboardSidenavItem
+              title={t('overview.sideMenu.institutionManagement.overview.subMenu.title')}
+              handleClick={() =>
+                onExit(() => history.push(party.partyId ? delegatesPath : delegatesRoute))
+              }
+              isSelected={isDelegateSelected}
+              icon={AssignmentIcon}
+              isPtPageVisible={false}
+            />
+          )}
           {canSeeSection && (
             <DashboardSidenavItem
               title={t('overview.sideMenu.institutionManagement.referents.title')}
               handleClick={() => onExit(() => history.push(party.partyId ? usersPath : usersRoute))}
               isSelected={isUserSelected}
               icon={PeopleAlt}
-              subMenuVisible={false}
               isPtPageVisible={false}
             />
           )}
@@ -98,7 +101,6 @@ export default function DashboardSideMenu({
               }
               isSelected={isGroupSelected}
               icon={SupervisedUserCircle}
-              subMenuVisible={false}
               isPtPageVisible={false}
             />
           )}

--- a/src/pages/dashboard/components/dashboardSideMenu/DashboardSidenavItem.tsx
+++ b/src/pages/dashboard/components/dashboardSideMenu/DashboardSidenavItem.tsx
@@ -3,24 +3,17 @@ import {
   ListItemText,
   ListItemIcon,
   Icon,
-  Collapse,
   List,
   Divider,
   Box,
 } from '@mui/material';
-import { ExpandLess, ExpandMore, SvgIconComponent } from '@mui/icons-material';
-import React from 'react';
+import { SvgIconComponent } from '@mui/icons-material';
 
 type Props = {
   handleClick: () => void;
   title: string;
   isSelected?: boolean;
-  isSubMenuSelected?: boolean;
   icon: SvgIconComponent;
-  subMenuVisible: boolean;
-  subMenuIcon?: SvgIconComponent;
-  subMenuTitle?: string;
-  handleClickSubMenu?: () => void;
   handleClickPtPage?: () => void;
   isPtPageVisible: boolean;
   ptIcon?: SvgIconComponent;
@@ -30,27 +23,15 @@ type Props = {
 
 export default function DashboardSidenavItem({
   handleClick,
-  handleClickSubMenu,
   title,
   isSelected,
-  isSubMenuSelected,
   icon,
-  subMenuVisible,
-  subMenuIcon,
-  subMenuTitle,
   isPtPageVisible,
   ptIcon,
   ptTitle,
   isPtSelected,
   handleClickPtPage,
 }: Props) {
-  const [open, setOpen] = React.useState(true);
-
-  const handleOpen = () => {
-    setOpen(!open);
-  };
-
-  const isSubMenuPresent = subMenuVisible && subMenuIcon && handleClickSubMenu;
   return (
     <List disablePadding>
       {isPtPageVisible && ptIcon && handleClickPtPage && (
@@ -91,34 +72,7 @@ export default function DashboardSidenavItem({
         </ListItemIcon>
 
         <ListItemText primary={title} />
-        {isSubMenuPresent && !isPtPageVisible && (
-          <>
-            {open ? (
-              <ExpandLess onClick={() => handleOpen()} />
-            ) : (
-              <ExpandMore onClick={() => handleOpen()} />
-            )}
-          </>
-        )}
       </ListItemButton>
-      {isSubMenuPresent && !isPtPageVisible && (
-        <Collapse in={open} timeout="auto" unmountOnExit>
-          <List component="div" disablePadding>
-            <ListItemButton
-              selected={isSubMenuSelected ?? false}
-              sx={{ pl: 4, height: '100%', maxWidth: 360, backgroundColor: 'background.paper' }}
-              onClick={() => {
-                handleClickSubMenu();
-              }}
-            >
-              <ListItemIcon>
-                <Icon component={subMenuIcon} />
-              </ListItemIcon>
-              <ListItemText primary={subMenuTitle} />
-            </ListItemButton>
-          </List>
-        </Collapse>
-      )}
     </List>
   );
 }


### PR DESCRIPTION
#### List of Changes

SELC-3032 Delegation button in side menu should be in top level and be able to be hidden with arrow button

#### Motivation and Context

Added change as requested

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally the app.
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.