### PR TITLE
SElC-3076 hide avaible products section for SA

### DIFF
--- a/src/pages/dashboardOverview/DashboardOverview.tsx
+++ b/src/pages/dashboardOverview/DashboardOverview.tsx
@@ -45,7 +45,7 @@ const DashboardOverview = ({ party, products }: Props) => {
 
   const showInfoBanner = party.institutionType === 'PA';
 
-  const isPt = party.institutionType === 'PT';
+  const isPtOrSa = party.institutionType === 'PT' || 'SA';
 
   return (
     <Box p={3} sx={{ width: '100%' }}>
@@ -76,7 +76,7 @@ const DashboardOverview = ({ party, products }: Props) => {
       <Grid item xs={12} mb={2} mt={5}>
         <ActiveProductsSection products={products} party={party} />
         {isAdmin &&
-          !isPt &&
+          !isPtOrSa &&
           products &&
           products.findIndex(
             (product) =>

--- a/src/pages/dashboardOverview/__test__/DashboardOverview.test.tsx
+++ b/src/pages/dashboardOverview/__test__/DashboardOverview.test.tsx
@@ -5,7 +5,6 @@ import { mockedPartyProducts } from '../../../services/__mocks__/productService'
 import { renderWithProviders } from '../../../utils/test-utils';
 import DashboardOverview from '../DashboardOverview';
 
-
 test('should render component DashboardOverview with empty party', async () => {
   renderWithProviders(
     <DashboardOverview
@@ -46,9 +45,13 @@ test('should render component DashboardOverview with empty party', async () => {
 
 test('should render component DashboardOverview with populated props and product prod-pagopa and institutionType GSP', async () => {
   const mockedGsp = mockedParties[11];
-  const { history } = renderWithProviders(<DashboardOverview party={mockedGsp} products={mockedPartyProducts} />);
+  const { history } = renderWithProviders(
+    <DashboardOverview party={mockedGsp} products={mockedPartyProducts} />
+  );
 
-  const delegationBanner = await screen.findByText('Delega la gestione dei prodotti a un Partner o a un Intermediario');
+  const delegationBanner = await screen.findByText(
+    'Delega la gestione dei prodotti a un Partner o a un Intermediario'
+  );
   expect(delegationBanner).toBeInTheDocument();
 
   fireEvent.click(await screen.findByText('Vai'));
@@ -59,10 +62,10 @@ test('should render component DashboardOverview with populated props and product
   expect(screen.queryByTestId('InfoOutlinedIcon')).not.toBeInTheDocument();
 });
 
-test('should render component DashboardOverview with populated props and product prod-io and institutionType PA', async () => {
-  const mockedPa = mockedParties[1];
-  renderWithProviders(<DashboardOverview party={mockedPa} products={mockedPartyProducts} />);
+test('should render component DashboardOverview with institutionType SA and Product Avaible section should not be visible', async () => {
+  const mockedSa = mockedParties[17];
+  renderWithProviders(<DashboardOverview party={mockedSa} products={mockedPartyProducts} />);
 
-  // info section is visible for PA
-  expect(await screen.findByTestId('InfoOutlinedIcon')).toBeInTheDocument();
+  // Avaible products section is not visible for SA
+  expect(screen.queryByText('Prodotti disponibili')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
SELC-3076 hide avaible products section for SA
<!--- Describe your changes in detail -->

#### Motivation and Context
A private SA cannot onboard on products other than interop so the section should be hidden
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Test locally and with unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.