### PR TITLE
SELC 3122 add loading spinner for retrieveBackOfficeUrl Api call

### DIFF
--- a/src/hooks/useTokenExchange.ts
+++ b/src/hooks/useTokenExchange.ts
@@ -36,9 +36,9 @@ export const useTokenExchange = () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     selectedEnvironment
-      ? retrieveBackOfficeUrl(selectedParty, product, selectedEnvironment)
+      ? (setLoading(true),
+        retrieveBackOfficeUrl(selectedParty, product, selectedEnvironment)
           .then((url) => {
-            setLoading(true);
             trackEvent(
               'DASHBOARD_OPEN_PRODUCT',
               {
@@ -59,10 +59,10 @@ export const useTokenExchange = () => {
               toNotify: true,
             })
           )
-          .finally(() => setLoading(false))
-      : retrieveBackOfficeUrl(selectedParty, product)
+          .finally(() => setLoading(false)))
+      : (setLoading(true),
+        retrieveBackOfficeUrl(selectedParty, product)
           .then((url) => {
-            setLoading(true);
             trackEvent(
               'DASHBOARD_OPEN_PRODUCT',
               {
@@ -83,7 +83,7 @@ export const useTokenExchange = () => {
               toNotify: true,
             })
           )
-          .finally(() => setLoading(false));
+          .finally(() => setLoading(false)));
   };
   return { invokeProductBo };
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
SELC 3122 add loading spinner for retrieveBackOfficeUrl Api call
<!--- Describe your changes in detail -->

#### Motivation and Context
When calling retrieveBackOfficeUrl  API there is a couple of seconds of delay with no feedback . Spinner added as feedback and to make the button unclickable again
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally with mocked and integration testing with real api
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.