### PR TITLE
[SELC-3459] fix: Allow onboarding to prod-pn only for some categories

### DIFF
--- a/src/pages/dashboardOverview/components/notActiveProductsSection/NotActiveProductsSection.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/NotActiveProductsSection.tsx
@@ -14,6 +14,17 @@ type Props = {
 
 export default function NotActiveProductsSection({ party, products }: Props) {
   const { t } = useTranslation();
+
+  const isOnboardingAllowedInProdPN = (category?: string): boolean => {
+    const allowedCategories = [
+      'Regioni, Province Autonome e loro Consorzi e Associazioni', // L4
+      'Comuni e loro Consorzi e Associazioni', // L6
+      "Citta' Metropolitane", // L45
+    ];
+
+    return category !== undefined && allowedCategories.includes(category);
+  };
+
   return (
     <React.Fragment>
       <TitleBox
@@ -37,6 +48,7 @@ export default function NotActiveProductsSection({ party, products }: Props) {
                     (subProduct) => !party.products.some((us) => us.productId === subProduct.id)
                   )))
           )
+          .filter((p) => p.id !== 'prod-pn' || isOnboardingAllowedInProdPN(party?.category))
           .map((product) => (
             <NotActiveProductCardContainer key={product.id} party={party} product={product} />
           ))}

--- a/src/services/__mocks__/partyService.ts
+++ b/src/services/__mocks__/partyService.ts
@@ -112,6 +112,24 @@ export const mockedBaseParties: Array<BaseParty> = [
     status: 'ACTIVE',
     userRole: 'ADMIN',
   },
+  {
+    partyId: '5dbec5e1-4262-4d00-a493-916e6171856a',
+    description: 'Asea Azienda Speciale',
+    status: 'ACTIVE',
+    userRole: 'ADMIN',
+  },
+  {
+    partyId: '2222222',
+    description: 'Test Metropolitane',
+    status: 'ACTIVE',
+    userRole: 'ADMIN',
+  },
+  {
+    partyId: '3333333',
+    description: 'Test Province Autonome',
+    status: 'ACTIVE',
+    userRole: 'ADMIN',
+  },
 ];
 
 export const mockedParties: Array<Party> = [
@@ -1032,6 +1050,138 @@ export const mockedParties: Array<Party> = [
         billing: {
           vatNumber: '94287592722',
           recipientCode: 'c_b988',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+    ],
+  },
+  {
+    partyId: '5dbec5e1-4262-4d00-a493-916e6171856a',
+    externalId: '01378640625',
+    originId: 'aasp',
+    origin: 'IPA',
+    institutionType: 'GSP',
+    description: 'Asea Azienda Speciale',
+    typology: 'Gestore di Pubblici Servizi',
+    category: 'Gestori di Pubblici Servizi',
+    fiscalCode: '01378640625',
+    digitalAddress: 'infoasea@legalmail.it',
+    registeredOffice: 'Rocca Dei Rettori, p.zza Castello',
+    zipCode: '82100',
+    geographicTaxonomies: [
+      {
+        code: 'ITA',
+        desc: 'ITALIA',
+      },
+    ],
+    products: [
+      {
+        productId: 'prod-interop',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+      {
+        productId: 'prod-interop-coll',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+    ],
+  },
+  {
+    partyId: '2222222',
+    externalId: '01378640625',
+    originId: 'aasp',
+    origin: 'IPA',
+    institutionType: 'PA',
+    description: 'Test Province Autonome',
+    typology: 'Publica Amministrazione',
+    category: 'Regioni, Province Autonome e loro Consorzi e Associazioni',
+    fiscalCode: '01378640625',
+    digitalAddress: 'infoasea@legalmail.it',
+    registeredOffice: 'Rocca Dei Rettori, p.zza Castello',
+    zipCode: '82100',
+    geographicTaxonomies: [
+      {
+        code: 'ITA',
+        desc: 'ITALIA',
+      },
+    ],
+    products: [
+      {
+        productId: 'prod-interop',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+      {
+        productId: 'prod-interop-coll',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+    ],
+  },
+  {
+    partyId: '3333333',
+    externalId: '01378640625',
+    originId: 'aasp',
+    origin: 'IPA',
+    institutionType: 'PA',
+    description: 'Test Metropolitane',
+    typology: 'Publica Amministrazione',
+    category: "Citta' Metropolitane",
+    fiscalCode: '01378640625',
+    digitalAddress: 'infoasea@legalmail.it',
+    registeredOffice: 'Rocca Dei Rettori, p.zza Castello',
+    zipCode: '82100',
+    geographicTaxonomies: [
+      {
+        code: 'ITA',
+        desc: 'ITALIA',
+      },
+    ],
+    products: [
+      {
+        productId: 'prod-interop',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
+          publicServices: false,
+        },
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
+      },
+      {
+        productId: 'prod-interop-coll',
+        userRole: 'ADMIN',
+        authorized: true,
+        billing: {
+          vatNumber: '01378640625',
+          recipientCode: 'codsdi',
           publicServices: false,
         },
         productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Check institution category and only allow categories L4, L6 and L45 to onboard to prod-io

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Through the dashboard page it was possibile to bypass the BE checks for categories allowed to onboard in prod-pn
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.