### PR TITLE
[SELC-3843] feat: Dynamic rendering of dashboard page for PT

### DIFF
--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -4089,7 +4089,7 @@
       },
       "OnboardingRequestResource" : {
         "title" : "OnboardingRequestResource",
-        "required" : [ "institutionInfo", "manager", "status" ],
+        "required" : [ "institutionInfo", "status" ],
         "type" : "object",
         "properties" : {
           "admins" : {

--- a/openApi/generated-dashboard/dashboard-swagger20.json
+++ b/openApi/generated-dashboard/dashboard-swagger20.json
@@ -3724,7 +3724,6 @@
       },
       "required": [
         "institutionInfo",
-        "manager",
         "status"
       ],
       "title": "OnboardingRequestResource",

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,9 +1,10 @@
 import { Box, Grid, useTheme } from '@mui/material';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from 'react-redux';
 import { Route, Switch, matchPath, useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
+import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/utils/routes-utils';
 import withProductRolesMap from '../../decorators/withProductsRolesMap';
 import withSelectedParty from '../../decorators/withSelectedParty';
 import withSelectedProduct from '../../decorators/withSelectedPartyProduct';
@@ -137,6 +138,16 @@ const Dashboard = () => {
     exact: true,
     strict: false,
   });
+
+  useEffect(() => {
+    if (party) {
+      const routePath =
+        party.institutionType === 'PT'
+          ? DASHBOARD_ROUTES.TECHPARTNER.path
+          : DASHBOARD_ROUTES.OVERVIEW.path;
+      history.push(resolvePathVariables(routePath, { partyId: party?.partyId ?? '' }));
+    }
+  }, [party]);
 
   return party && products ? (
     <Grid


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Once you select an Instititution of type PT you should be rendered in the "your institution page" not overview page
Remove required for manager in swagger
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.