### PR TITLE
[SELC-2278]: Feat: Integration with mix panel events for premium flow

### DIFF
--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
@@ -1,6 +1,7 @@
 import { Grid } from '@mui/material';
 import { useUserNotify } from '@pagopa/selfcare-common-frontend';
 import { useTranslation } from 'react-i18next';
+import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { Party } from '../../../../../model/Party';
 import { Product } from '../../../../../model/Product';
 import { ENV } from '../../../../../utils/env';
@@ -30,6 +31,13 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
   const goToOnboarding = (product: Product, party: Party): void => {
     const subUnitType = party.subunitType ? `&subunitType=${party.subunitType}` : '';
     const subUnitCode = party.subunitCode ? `&subunitCode=${party.subunitCode}` : '';
+
+    if (product.id === 'prod-io-premium') {
+      trackEvent('PREMIUM_CTA_JOIN', {
+        cta_referral: window.location.href,
+        ctaId: t('overview.notActiveProducts.joinButton'),
+      });
+    }
 
     window.location.assign(
       `${ENV.URL_FE.ONBOARDING}/${product.id}${

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
@@ -32,7 +32,7 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
     const subUnitType = party.subunitType ? `&subunitType=${party.subunitType}` : '';
     const subUnitCode = party.subunitCode ? `&subunitCode=${party.subunitCode}` : '';
 
-    if (product.id === 'prod-io-premium') {
+    if (baseProductWithExistingSubProductNotOnboarded && existingSubProductNotOnboarded.id === 'prod-io-premium') {
       trackEvent('PREMIUM_CTA_JOIN', {
         cta_referral: window.location.href,
         ctaId: t('overview.notActiveProducts.joinButton'),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added missing event in onboarding io premiuim flow
Changed events called in wrong place.
Add missing properties in payload object

#### Motivation and Context
In order to follow the user jorney during onboarding to prod-io-premuim and to be able to track in through mix panel added events that can be traced in mix panel dashboard.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.