### PR TITLE
[SELC-4779] Feat: Add link to how to delegate documentation

### DIFF
--- a/src/pages/dashboardDelegationsAdd/components/AddDelegationForm.tsx
+++ b/src/pages/dashboardDelegationsAdd/components/AddDelegationForm.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   Grid,
   InputLabel,
+  Link,
   MenuItem,
   OutlinedInput,
   Select,
@@ -190,12 +191,18 @@ export default function AddDelegationForm({
             {t('addDelegationPage.addOneDelegation')}
           </Typography>
           <Typography variant="body1">{t('addDelegationPage.formSubTitle')}</Typography>
-          {/*
-          TODO hide MUI Link until href for link is avaible
-          <Link href={'#'} sx={{ fontWeight: 'bold' }} mt={1}>
-            {t('addDelegationPage.findOutMore')}
-          </Link>
-          */}
+          {
+            <Link
+              href={
+                'https://docs.pagopa.it/area-riservata/area-riservata/come-funziona/come-delegare-la-gestione'
+              }
+              target="_blank"
+              sx={{ fontWeight: 'bold', color: 'primary.main', fontSize: '14px' }}
+              mt={1}
+            >
+              {t('addDelegationPage.findOutMore')}
+            </Link>
+          }
         </Grid>
         <Grid item xs={6} mb={3}>
           <Typography variant="subtitle1" fontSize={'16px'} mb={2}>

--- a/src/pages/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
+++ b/src/pages/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
@@ -39,3 +39,21 @@ test('should display the choose product autocomplete input empty if there are no
 
   expect(screen.queryByText('App IO')).not.toBeInTheDocument();
 });
+
+test('should display documentation link with correct href and text content', async () => {
+  renderWithProviders(
+    <AddDelegationForm authorizedDelegableProducts={mockedPartyProducts} party={mockedParties[0]} />
+  );
+  const href =
+    'https://docs.pagopa.it/area-riservata/area-riservata/come-funziona/come-delegare-la-gestione';
+  const linkElement = screen.getByText('Dubbi? Vai al manuale');
+
+  expect(linkElement).toHaveAttribute('href', href);
+
+  expect(linkElement).toHaveStyle(`
+    font-weight: 700;
+    font-size: 14px;
+  `);
+
+  fireEvent.click(linkElement);
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added link button for documentation
added unit test for link
<!--- Describe your changes in detail -->

#### Motivation and Context
To explain to the users how to delegate an institution a documentation page was created and a link was added that sends the user to that page
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally and unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.