### PR TITLE
[SELC-4781] Improve Autocomplete UX: Filter suggestions only after 11 characters

### DIFF
--- a/src/pages/dashboardDelegationsAdd/components/AddDelegationForm.tsx
+++ b/src/pages/dashboardDelegationsAdd/components/AddDelegationForm.tsx
@@ -61,6 +61,7 @@ export default function AddDelegationForm({
   const [techPartnerSelected, setTechPartnerSelected] = useState<BrokerResource>();
   const [delegationsList, setDelegationsList] = useState<Array<DelegationResource>>();
   const [selectedRadioValue, setSelectedRadioValue] = useState<string>('institutionName');
+  const [inputValue, setInputValue] = useState<string>('');
   const delegationsListRef = useRef(delegationsList);
 
   useEffect(() => {
@@ -301,6 +302,9 @@ export default function AddDelegationForm({
               onChange={(_e, selectedPb: any) => {
                 setTechPartnerSelected(selectedPb);
               }}
+              onInputChange={(_e, inputValue) => {
+                setInputValue(inputValue);
+              }}
               sx={{
                 '.MuiOutlinedInput-root.MuiInputBase-root.MuiInputBase-adornedEnd.MuiAutocomplete-inputRoot':
                   {
@@ -313,14 +317,16 @@ export default function AddDelegationForm({
                 },
               }}
               filterOptions={(productBrokers, { inputValue }) => {
-                if (selectedRadioValue === 'fiscalCode') {
+                if (selectedRadioValue === 'fiscalCode' && inputValue.length === 11) {
                   return productBrokers.filter((productBrokers) =>
                     productBrokers?.code?.toLowerCase().includes(inputValue.toLowerCase())
                   );
-                } else {
+                } else if (selectedRadioValue === 'institutionName') {
                   return productBrokers.filter((productBrokers) =>
                     productBrokers?.description?.toLowerCase().includes(inputValue.toLowerCase())
                   );
+                } else {
+                  return [];
                 }
               }}
               componentsProps={{
@@ -339,6 +345,13 @@ export default function AddDelegationForm({
                     },
                     overflowY: 'auto',
                     maxHeight: '200px',
+                    '.MuiAutocomplete-noOptions': () => ({
+                      display:
+                        (selectedRadioValue === 'fiscalCode' && !inputValue.length) ||
+                        techPartnerSelected
+                          ? 'none'
+                          : 'block',
+                    }),
                   },
                 },
               }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Modified the Autocomplete component behavior to initiate filtering only after the user enters - 11 characters in the input field.
Previously, filtering occurred on any character input.
<!--- Describe your changes in detail -->

#### Motivation and Context
This change aims to improve the user experience by reducing unnecessary filtering and visual clutter when the user types short queries.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Manual testing was conducted to ensure the functionality
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.