### PR TITLE
[SELC-4969] Feat: dynamic query params for io premium

### DIFF
--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
@@ -31,8 +31,15 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
   const goToOnboarding = (product: Product, party: Party): void => {
     const subUnitType = party.subunitType ? `&subunitType=${party.subunitType}` : '';
     const subUnitCode = party.subunitCode ? `&subunitCode=${party.subunitCode}` : '';
+    const queryParam =
+      existingSubProductNotOnboarded?.id === 'prod-io-premium'
+        ? `?partyId=${party.partyId}`
+        : `?partyExternalId=${party.externalId}`;
 
-    if (baseProductWithExistingSubProductNotOnboarded && existingSubProductNotOnboarded.id === 'prod-io-premium') {
+    if (
+      baseProductWithExistingSubProductNotOnboarded &&
+      existingSubProductNotOnboarded.id === 'prod-io-premium'
+    ) {
       trackEvent('PREMIUM_CTA_JOIN', {
         cta_referral: window.location.href,
         ctaId: t('overview.notActiveProducts.joinButton'),
@@ -42,7 +49,7 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
     window.location.assign(
       `${ENV.URL_FE.ONBOARDING}/${product.id}${
         baseProductWithExistingSubProductNotOnboarded ? `/${existingSubProductNotOnboarded.id}` : ''
-      }?partyExternalId=${party.externalId}${subUnitType}${subUnitCode}`
+      }${queryParam}${subUnitType}${subUnitCode}`
     );
   };
 

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/__tests__/NotActiveProductCard.test.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/__tests__/NotActiveProductCard.test.tsx
@@ -80,7 +80,7 @@ describe('test onboarding', () => {
     fireEvent.click(button);
 
     expect(mockedLocation.assign).toBeCalledWith(
-      `http://selfcare/onboarding/${mockedProduct.id}?partyExternalId=${mockedParties[0].externalId}`
+      `http://selfcare/onboarding/${mockedProduct.id}?partyId=${mockedParties[0].partyId}`
     );
   });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[SELC-4969] Feat: dynamic query params for io premium
<!--- Describe your changes in detail -->

#### Motivation and Context
Following the new refactor in ms Onboarding it is necessary to send the partyId in place of externalId only for prod-io-premium
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4969]: https://pagopa.atlassian.net/browse/SELC-4969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ