### PR TITLE
[SELC-5536] feat: Hide invoice menu for non invoicable product

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -99,7 +99,6 @@ const Dashboard = () => {
 
   const { getAllProductsWithPermission, hasPermission } = usePermissions();
 
-  const canSeeBillingSection = getAllProductsWithPermission(Actions.ViewBilling).length > 0;
   const canSeeHandleDelegations =
     getAllProductsWithPermission(Actions.ViewManagedInstitutions).length > 0;
   const canSeeAddDelegation = getAllProductsWithPermission(Actions.ViewDelegations).length > 0;
@@ -133,7 +132,7 @@ const Dashboard = () => {
   const isInvoiceSectionVisible = !!products?.some(
     (prod) =>
       prod.invoiceable &&
-      party?.products.some((partyProd) => partyProd.productId === prod.id && canSeeBillingSection)
+      party?.products.some((partyProd) => partyProd.productId === prod.id && hasPermission(partyProd.productId, Actions.ViewBilling))
   );
 
   const productsMap: ProductsMap =
@@ -229,7 +228,7 @@ const Dashboard = () => {
                 hideLabels={hideLabels}
               />
               <Box sx={{ position: 'absolute', bottom: '0', width: '100%' }}>
-                <Divider />
+                <Divider sx={{ marginTop: '80px' }} />
 
                 <Button
                   fullWidth

--- a/src/services/__mocks__/partyService.ts
+++ b/src/services/__mocks__/partyService.ts
@@ -388,7 +388,7 @@ export const mockedParties: Array<Party> = [
       },
       {
         productId: 'prod-pn',
-        productOnBoardingStatus: ProductOnBoardingStatusEnum.PENDING,
+        productOnBoardingStatus: ProductOnBoardingStatusEnum.ACTIVE,
         userRole: 'ADMIN',
         billing: {
           vatNumber: '3395867495',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Hidden the from the side menu the option for invoice 
<!--- Describe your changes in detail -->

#### Motivation and Context
As a user not authorized on an invoicable product i should not be able to see the link to invoice
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in local by mocking an institution with active onboarding on send product and one without it.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.