### PR TITLE
[SELC-5583] Feat: Update Product Cards to Show Role-Based Management Status in Active Products Section

### DIFF
--- a/src/api/__mocks__/DashboardApiClient.ts
+++ b/src/api/__mocks__/DashboardApiClient.ts
@@ -54,8 +54,8 @@ export const mockedInstitutionResources: Array<InstitutionResource> = [
 export const mockedProductResources: Array<ProductsResource> = [
   {
     logo: 'https://selcdcheckoutsa.z6.web.core.windows.net/resources/products/prod-io/logo.png',
-    title: 'App IO',
-    description: 'App IO description',
+    title: 'IO',
+    description: 'IO description',
     id: '1',
     status: StatusEnum.ACTIVE,
     urlBO: 'http://appio/bo#<IdentityToken>',
@@ -177,7 +177,7 @@ export const mockedProductUserResource: Array<ProductUserResource> = [
     email: 'address' as EmailString,
     product: {
       id: 'prod-io',
-      title: 'App IO',
+      title: 'IO',
       roleInfos: [
         {
           relationshipId: 'relationshipId',
@@ -197,7 +197,7 @@ export const mockedProductUserResource: Array<ProductUserResource> = [
     email: 'address2' as EmailString,
     product: {
       id: 'prod-io',
-      title: 'App IO',
+      title: 'IO',
       roleInfos: [
         {
           relationshipId: 'relationshipId2',

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -40,7 +40,7 @@ export default {
     moreInformationOnRoles:'Più informazioni sui ruoli',
   },
   activeProductCard: {
-    disableInfo: 'Per gestire questo prodotto, chiedi a uno dei suoi Amministratori',
+    disableInfo: 'Non hai un ruolo per gestire questo prodotto',
   },
   overview: {
     title: 'Panoramica',

--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { render, waitFor, screen, fireEvent } from '@testing-library/react';
-import Dashboard from '../Dashboard';
-import { Provider } from 'react-redux';
-import { createStore } from '../../../redux/store';
-import { verifyMockExecution as verifySelectedPartyMockExecution } from '../../../decorators/__mocks__/withSelectedParty';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Provider } from 'react-redux';
 import { Router } from 'react-router';
+import { verifyMockExecution as verifySelectedPartyMockExecution } from '../../../decorators/__mocks__/withSelectedParty';
+import { createStore } from '../../../redux/store';
+import Dashboard from '../Dashboard';
 
 jest.mock('../../../decorators/withSelectedParty');
+jest.mock('@mui/material/useMediaQuery');
 
 const oldWindowLocation = global.window.location;
 const mockedLocation = {
@@ -72,4 +74,27 @@ test('Test routing', async () => {
 
   // history.push('/dashboard/13/prId/users/798');
   // await waitFor(() => expect(history.location.pathname).toBe('/dashboard/13/prId/users'));
+});
+
+test('Test rendering on mobile', async () => {
+  (useMediaQuery as jest.Mock).mockReturnValue(true);
+
+  renderDashboard();
+
+  const overviewButton = await waitFor(() => screen.getByText('Panoramica'));
+  fireEvent.click(overviewButton);
+
+  const drawer = await waitFor(() => screen.getByRole('presentation'));
+  expect(drawer).toBeInTheDocument();
+
+  const drawerNav = within(drawer).getByRole('navigation');
+
+  const overviewButtonInDrawer = within(drawerNav).getByText('Panoramica');
+  fireEvent.click(overviewButtonInDrawer);
+
+  fireEvent.keyDown(drawer, { key: 'Escape' });
+
+  await waitFor(() => {
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument(); 
+  });
 });

--- a/src/pages/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
+++ b/src/pages/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
@@ -24,7 +24,7 @@ test('search by name', async () => {
     />
   );
 
-  expect(screen.getByText('App IO')).toBeInTheDocument();
+  expect(screen.getByText('IO')).toBeInTheDocument();
   const autocompleteInput = screen.getByLabelText(
     'Inserisci la ragione sociale'
   ) as HTMLInputElement;
@@ -79,7 +79,7 @@ test('should display the choose product autocomplete input empty if there are no
   const chooseProduct = document.getElementById('select-product-choose') as HTMLInputElement;
   expect(chooseProduct).toBeInTheDocument();
 
-  expect(screen.queryByText('App IO')).not.toBeInTheDocument();
+  expect(screen.queryByText('IO')).not.toBeInTheDocument();
 });
 
 test('should display documentation link with correct href and text content', async () => {

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/__tests__/NotActiveProductsSection.test.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/__tests__/NotActiveProductsSection.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { mockedParties } from '../../../../../services/__mocks__/partyService';
+import { mockedPartyProducts } from '../../../../../services/__mocks__/productService';
+import { renderWithProviders } from '../../../../../utils/test-utils';
+import NotActiveProductsSection from '../NotActiveProductsSection';
+
+describe('NotActiveProductsSection test suite', () => {
+  test('NotActiveProductsSection render', () => {
+    renderWithProviders(<NotActiveProductsSection products={[]} party={mockedParties[0]} />);
+  });
+
+  test('NotActiveProductsSection render with products', () => {
+    renderWithProviders(
+      <NotActiveProductsSection products={mockedPartyProducts} party={mockedParties[1]} />
+    );
+  });
+
+  test('NotActiveProductsSection render with products', () => {
+    renderWithProviders(
+      <NotActiveProductsSection products={mockedPartyProducts} party={mockedParties[3]} />
+    );
+  });
+});

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCard.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCard.tsx
@@ -55,10 +55,10 @@ export default function NotActiveProductCard({
   };
 
   const renderTitleForIoPremium = (title: string) => {
-    if (title && title.toLowerCase() === 'app io premium') {
+    if (title && title.toLowerCase() === 'io premium') {
       const spliTitle = title.split(' ');
-      const baseName = `${spliTitle[0]} ${spliTitle[1]}`;
-      const subName = `${spliTitle[2]}`;
+      const baseName = `${spliTitle[0]}`;
+      const subName = `${spliTitle[1]}`;
       return (
         <Typography
           variant="h6"

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCard.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCard.tsx
@@ -55,7 +55,7 @@ export default function NotActiveProductCard({
   };
 
   const renderTitleForIoPremium = (title: string) => {
-    if (title && title.toLowerCase() === 'io premium') {
+    if (title && title.toLowerCase().includes('io premium')) {
       const spliTitle = title.split(' ');
       const baseName = `${spliTitle[0]}`;
       const subName = `${spliTitle[1]}`;

--- a/src/pages/dashboardTechnologyPartnerPage/__tests__/utils.test.ts
+++ b/src/pages/dashboardTechnologyPartnerPage/__tests__/utils.test.ts
@@ -45,9 +45,9 @@ describe('compareStrings', () => {
 
 describe('codeToLabelProduct', () => {
   it('should return the correct label for product code', () => {
-    expect(codeToLabelProduct('prod-io')).toBe('App Io');
+    expect(codeToLabelProduct('prod-io')).toBe('Io');
     expect(codeToLabelProduct('prod-pagopa')).toBe('Piattaforma pagoPA');
-    expect(codeToLabelProduct('prod-io, prod-pagopa')).toBe('App Io, Piattaforma pagoPA');
+    expect(codeToLabelProduct('prod-io, prod-pagopa')).toBe('Io, Piattaforma pagoPA');
   });
 
   it('should return an empty string for unknown product code', () => {

--- a/src/services/__mocks__/productService.ts
+++ b/src/services/__mocks__/productService.ts
@@ -5,8 +5,8 @@ import { ProductRole } from '../../model/ProductRole';
 export const mockedPartyProducts: Array<Product> = [
   {
     logo: 'https://selcdcheckoutsa.z6.web.core.windows.net/resources/products/prod-io/logo.svg',
-    title: 'App IO',
-    description: 'App IO description',
+    title: 'IO',
+    description: 'IO description',
     id: 'prod-io',
     status: StatusEnum.ACTIVE,
     urlPublic: 'https://io.italia.it/ ',
@@ -16,7 +16,7 @@ export const mockedPartyProducts: Array<Product> = [
     subProducts: [
       {
         id: 'prod-io-premium',
-        title: 'App IO Premium',
+        title: 'IO Premium',
         status: StatusEnum.ACTIVE,
         delegable: false,
         imageUrl:

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -24,12 +24,11 @@ export const compareDates = (
   export const codeToLabelProduct = (code: string) => {
     switch (code) {
       case 'prod-io':
-        return 'App Io';
+        return 'Io';
       case 'prod-pagopa':
         return 'Piattaforma pagoPA';
       case 'prod-io, prod-pagopa':
-        return 'App Io, Piattaforma pagoPA';
-  
+        return 'Io, Piattaforma pagoPA';
       default:
         return '';
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 Updated the text displayed on product cards in the "Active Products" section to indicate when a user does not have the role required to manage a product.
 updated unit tests
<!--- Describe your changes in detail -->

#### Motivation and Context
This update improves clarity for users by clearly distinguishing between products they can manage and those they cannot. This distinction is crucial for effective product management and ensures that users are aware of their access limitations.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by running the application in local and mocking a user without permissions on the product.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.