### PR TITLE
[SELC-5780] Fix: call api /roles only for authorized products

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -63,7 +63,7 @@ const DashboardHeader = ({ onExit, loggedUser, parties }: Props) => {
 
   const hasMoreThanOneInteropEnv = authorizedInteropProducts.length > 1;
 
-  const onboardedPartyProducts = party?.products.filter(
+  const authorizedPartyProducts = party?.products.filter(
     (pp) =>
       pp.productOnBoardingStatus === 'ACTIVE' &&
       (hasPermission(pp.productId ?? '', Actions.AccessProductBackoffice) ||
@@ -72,8 +72,8 @@ const DashboardHeader = ({ onExit, loggedUser, parties }: Props) => {
 
   const activeProducts: Array<Product> = useMemo(
     () =>
-      products?.filter((p) => onboardedPartyProducts?.some((op) => op.productId === p.id)) ?? [],
-    [onboardedPartyProducts]
+      products?.filter((p) => authorizedPartyProducts?.some((op) => op.productId === p.id)) ?? [],
+    [authorizedPartyProducts]
   );
 
   // eslint-disable-next-line functional/immutable-data

--- a/src/hooks/useProductsRolesMap.tsx
+++ b/src/hooks/useProductsRolesMap.tsx
@@ -1,4 +1,6 @@
+import { usePermissions } from '@pagopa/selfcare-common-frontend/lib';
 import useReduxCachedValue from '@pagopa/selfcare-common-frontend/lib/hooks/useReduxCachedValue';
+import { Actions } from '@pagopa/selfcare-common-frontend/lib/utils/constants';
 import { useMemo } from 'react';
 import { Party } from '../model/Party';
 import {
@@ -15,26 +17,33 @@ export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
   const party = useAppSelector(partiesSelectors.selectPartySelected);
   const products = useAppSelector(partiesSelectors.selectPartySelectedProducts);
   const productsRolesMap = useAppSelector(partiesSelectors.selectPartySelectedProductsRolesMap);
+  const { hasPermission } = usePermissions();
 
-  const activeProducts = useMemo(
+  const activeAndAccessibleProducts = useMemo(
     () =>
       products?.filter((p) =>
         party?.products.some(
-          (us) => us.productId === p.id && us.productOnBoardingStatus === 'ACTIVE'
+          (us) =>
+            us.productId === p.id &&
+            us.productOnBoardingStatus === 'ACTIVE' &&
+            hasPermission(us.productId ?? '', Actions.AccessProductBackoffice)
         )
       ),
     [products, party?.products]
   );
 
   const fetchProductRolesNotYetCached = async (): Promise<ProductsRolesMap> => {
-    if (!activeProducts) {
-      return new Promise((resolve) => resolve(productsRolesMap));
+    if (!activeAndAccessibleProducts) {
+      return Promise.resolve(productsRolesMap);
     }
 
-    const promises: Array<Promise<[string, ProductRolesLists]>> = activeProducts
+    const promises: Array<Promise<[string, ProductRolesLists]>> = activeAndAccessibleProducts
       .filter((p) => !productsRolesMap[p.id])
       .map((p) =>
-        fetchProductRoles(p, party as Party).then((roles) => [p.id, productRoles2ProductRolesList(roles)])
+        fetchProductRoles(p, party as Party).then((roles) => [
+          p.id,
+          productRoles2ProductRolesList(roles),
+        ])
       );
     const fetched: Array<[string, ProductRolesLists]> = await Promise.all(promises);
 
@@ -45,9 +54,9 @@ export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
     'PRODUCTS_ROLES',
     fetchProductRolesNotYetCached,
     (state: RootState) =>
-      !activeProducts ||
+      !activeAndAccessibleProducts ||
       (state.parties.selectedProductsRolesMap &&
-        !activeProducts.find(
+        !activeAndAccessibleProducts.find(
           (p) => !(state.parties.selectedProductsRolesMap as ProductsRolesMap)[p.id]
         ))
         ? state.parties.selectedProductsRolesMap

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -164,15 +164,19 @@ const Dashboard = () => {
     getAllProductsWithPermission(Actions.ViewDelegations).length > 0;
 
   const isHandleDelegationsVisible = useMemo(() => {
-    const hasPermissionForManagedInstitutions =
+    const canDelegateSeeHandleDelegations =
+      delegableProducts.length > 0 &&
+      (isPT || hasDelegation) &&
       getAllProductsWithPermission(Actions.ViewManagedInstitutions).length > 0;
-    const canShowDelegations = delegableProducts.length > 0 && (isPT || hasDelegation);
 
-    return (
-      (hasPermissionForManagedInstitutions && canShowDelegations) ||
-      canAggregatorSeeHandleDelegations
-    );
-  }, [authorizedDelegableProducts, isPT, hasDelegation, canAggregatorSeeHandleDelegations]);
+    return canDelegateSeeHandleDelegations || canAggregatorSeeHandleDelegations;
+  }, [
+    authorizedDelegableProducts,
+    isPT,
+    hasDelegation,
+    canAggregatorSeeHandleDelegations,
+    delegableProducts,
+  ]);
 
   // Check if the current route matches any path in the array
   // TODO `${ENV.ROUTES.USERS}/add` add after release in PROD


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Changed the list of products that are passed to user micro frontend by checking if the user is authorized to handle the users of that product.
<!--- Describe your changes in detail -->

#### Motivation and Context
To fix a bug where the /roles api was called for not authorized products leading in some cases like interop where the filters roles select would have extra options in user micro frontend
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by deploying the branch in dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.