### PR TITLE
[SELC-5831] Feat: use ListProductUsers to handle users section visibility

### DIFF
--- a/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
+++ b/src/pages/dashboard/components/dashboardSideMenu/DashboardSideMenu.tsx
@@ -55,7 +55,7 @@ export default function DashboardSideMenu({
   const ptRoute = DASHBOARD_ROUTES.TECHPARTNER.path;
   const { getAllProductsWithPermission } = usePermissions();
 
-  const canSeeUsers = getAllProductsWithPermission(Actions.ManageProductUsers).length > 0;
+  const canSeeUsers = getAllProductsWithPermission(Actions.ListProductUsers).length > 0;
   const canSeeGroups = getAllProductsWithPermission(Actions.ManageProductGroups).length > 0;
 
   const overviewPath = resolvePathVariables(overviewRoute, {

--- a/src/services/__mocks__/partyService.ts
+++ b/src/services/__mocks__/partyService.ts
@@ -262,6 +262,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListActiveProducts,
           Actions.ListAvailableProducts,
           Actions.ManageProductGroups,
+          Actions.ListProductUsers,
           Actions.ManageProductUsers,
           Actions.AccessProductBackoffice,
           Actions.ViewDelegations,
@@ -309,6 +310,7 @@ export const mockedParties: Array<Party> = [
         userProductActions: [
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -329,6 +331,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.ManageProductGroups,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.AccessProductBackoffice,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -348,6 +351,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListActiveProducts,
           Actions.ListAvailableProducts,
           Actions.ManageProductGroups,
+          Actions.ListProductUsers,
           Actions.AccessProductBackoffice,
         ],
       },
@@ -362,7 +366,7 @@ export const mockedParties: Array<Party> = [
           recipientCode: 'NBG455B',
           publicServices: true,
         },
-        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers],
+        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers, Actions.ListProductUsers],
       },
       {
         productId: 'prod-interop-coll',
@@ -374,7 +378,7 @@ export const mockedParties: Array<Party> = [
           recipientCode: 'NBG455B',
           publicServices: true,
         },
-        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers]
+        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers, Actions.ListProductUsers]
       },
       {
         productId: 'prod-interop-atst',
@@ -386,7 +390,7 @@ export const mockedParties: Array<Party> = [
           recipientCode: 'NBG455B',
           publicServices: true,
         },
-        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers]
+        userProductActions: [Actions.AccessProductBackoffice, Actions.ManageProductUsers, Actions.ListProductUsers]
       },
       {
         productId: 'prod-pn',
@@ -400,6 +404,7 @@ export const mockedParties: Array<Party> = [
         userProductActions: [
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -456,6 +461,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListActiveProducts,
           Actions.AccessProductBackoffice,
           Actions.ViewBilling,
+          Actions.ListProductUsers,
         ],
       },
     ],
@@ -497,6 +503,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -517,6 +524,7 @@ export const mockedParties: Array<Party> = [
         userProductActions: [
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -561,6 +569,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -578,6 +587,7 @@ export const mockedParties: Array<Party> = [
         },
         userProductActions: [
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -619,6 +629,7 @@ export const mockedParties: Array<Party> = [
         },
         userProductActions: [
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -677,6 +688,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,
@@ -707,6 +719,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewManagedInstitutions,
@@ -1214,6 +1227,7 @@ export const mockedParties: Array<Party> = [
           Actions.ListAvailableProducts,
           Actions.AccessProductBackoffice,
           Actions.ManageProductUsers,
+          Actions.ListProductUsers,
           Actions.ManageProductGroups,
           Actions.ViewDelegations,
           Actions.ViewBilling,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added the new action Actions.ListProductUsers
adapted mocked data
<!--- Describe your changes in detail -->

#### Motivation and Context
To differentiate admin of the aggregator from the admin of the aggregated user.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.