### PR TITLE
[SELC-5822] fix: change method used for the redirect to refresh the selected party on header

### DIFF
--- a/src/pages/dashboardTechnologyPartnerPage/TechPartnersTable.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/TechPartnersTable.tsx
@@ -22,7 +22,6 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/lib/utils/routes-utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router-dom';
 import { DelegationWithInfo } from '../../api/generated/b4f-dashboard/DelegationWithInfo';
 import { useAppSelector } from '../../redux/hooks';
 import { partiesSelectors } from '../../redux/slices/partiesSlice';
@@ -38,7 +37,6 @@ type Props = {
 
 export default function TechPartnersTable({ delegationsWithoutDuplicates }: Readonly<Props>) {
   const { t } = useTranslation();
-  const history = useHistory();
   const [order, setOrder] = useState<'asc' | 'desc'>('asc');
   const [filterBy, setFilterBy] = useState<string>('');
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/pages/dashboardTechnologyPartnerPage/TechPartnersTable.tsx
+++ b/src/pages/dashboardTechnologyPartnerPage/TechPartnersTable.tsx
@@ -228,11 +228,12 @@ export default function TechPartnersTable({ delegationsWithoutDuplicates }: Read
                                     fontSize: '16px',
                                   }}
                                   onClick={() => {
-                                    history.push(
+                                    window.location.assign(
                                       resolvePathVariables(ROUTES.PARTY_DASHBOARD.path, {
-                                        partyId: item.institutionId ?? '',
+                                        partyId: item?.institutionId ?? '',
                                       })
                                     );
+                                    
                                   }}
                                 >
                                   {item.institutionName ?? ''}


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
changed method of redirect from history to window object
<!--- Describe your changes in detail -->

#### Motivation and Context
The selected party on header does not refresh with history.push because the header comes from an external library
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.