### PR TITLE
[SELC-6105] Fix: add check for length of backOfficeEnvironmentConfigurations

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -147,7 +147,8 @@ const DashboardHeader = ({ onExit, loggedUser, parties }: Props) => {
               setOpenCustomEnvInteropModal(true);
             } else if (
               actualSelectedParty.current &&
-              selectedProduct?.backOfficeEnvironmentConfigurations
+              selectedProduct?.backOfficeEnvironmentConfigurations &&
+              selectedProduct?.backOfficeEnvironmentConfigurations.length > 0
             ) {
               setOpenGenericEnvProductModal(true);
             } else if (selectedProduct && selectedProduct.id !== 'prod-selfcare') {

--- a/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/activeProductsSection/components/ActiveProductCardContainer.tsx
@@ -70,6 +70,7 @@ export default function ActiveProductCardContainer({
             hasMoreThanOneInteropEnv && startWithProductInterop(productOnboarded.id)
               ? setOpenCustomEnvInteropModal(true)
               : productOnboarded?.backOfficeEnvironmentConfigurations &&
+                productOnboarded.backOfficeEnvironmentConfigurations.length > 0 &&
                 productOnboarded.id !== INTEROP_PRODUCT_ENUM.INTEROP
               ? setOpenGenericEnvProductModal(true)
               : invokeProductBo(productOnboarded, party, undefined, lang)

--- a/src/services/__mocks__/productService.ts
+++ b/src/services/__mocks__/productService.ts
@@ -42,16 +42,7 @@ export const mockedPartyProducts: Array<Product> = [
     urlPublic: 'http://notifiche/public',
     imageUrl:
       'https://selcdcheckoutsa.z6.web.core.windows.net/resources/products/default/depict-image.jpeg',
-    backOfficeEnvironmentConfigurations: [
-      {
-        environment: 'test1',
-        url: 'www.test1.com',
-      },
-      {
-        environment: 'test2',
-        url: 'www.test2.com',
-      },
-    ],
+    backOfficeEnvironmentConfigurations: [],
     subProducts: [],
     logoBgColor: 'pagoPA.main',
     delegable: false,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
add check for length of backOfficeEnvironmentConfigurations
<!--- Describe your changes in detail -->

#### Motivation and Context
The modal should not be visible if the backOfficeEnvironmentConfigurations is empty
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by mocking the bug in local enviroment and verying the fix
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.