### PR TITLE
[SELC-6532] feat: Allow onboarding on pagoPA Insights only for psp

### DIFF
--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
@@ -100,7 +100,7 @@ export default function NotActiveProductCardContainer({ party, product }: Readon
   return (
     <Grid item xs={12} sm={6} lg={4} xl={3} key={product.id}>
       <NotActiveProductCard
-        image={displayProduct.imageUrl}
+        image={displayProduct.imageUrl ?? product.imageUrl}
         urlLogo={displayProduct.logo ?? product.logo}
         title={displayProduct.title ?? product.title}
         description={displayProduct.description ?? product.description}

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/NotActiveProductCardContainer.tsx
@@ -13,7 +13,7 @@ type Props = {
   product: Product;
 };
 
-export default function NotActiveProductCardContainer({ party, product }: Props) {
+export default function NotActiveProductCardContainer({ party, product }: Readonly<Props>) {
   const { t } = useTranslation();
   const addNotify = useUserNotify();
   const addError = useErrorDispatcher();
@@ -34,8 +34,7 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
     const subUnitType = party.subunitType ? `&subunitType=${party.subunitType}` : '';
     const subUnitCode = party.subunitCode ? `&subunitCode=${party.subunitCode}` : '';
     const queryParam =
-      baseProductWithExistingSubProductNotOnboarded &&
-      existingSubProductNotOnboarded?.id
+      baseProductWithExistingSubProductNotOnboarded && existingSubProductNotOnboarded?.id
         ? `?partyId=${party.partyId}`
         : `?partyExternalId=${party.externalId}`;
 
@@ -94,43 +93,25 @@ export default function NotActiveProductCardContainer({ party, product }: Props)
     });
   };
 
+  const displayProduct = baseProductWithExistingSubProductNotOnboarded
+    ? existingSubProductNotOnboarded
+    : product;
+
   return (
-    <>
-      <Grid item xs={12} sm={6} lg={4} xl={3} key={product.id}>
-        <NotActiveProductCard
-          image={
-            baseProductWithExistingSubProductNotOnboarded
-              ? existingSubProductNotOnboarded.imageUrl
-              : product.imageUrl
-          }
-          urlLogo={
-            baseProductWithExistingSubProductNotOnboarded
-              ? (existingSubProductNotOnboarded.logo as string)
-              : product.logo
-          }
-          title={
-            baseProductWithExistingSubProductNotOnboarded && existingSubProductNotOnboarded.title
-              ? existingSubProductNotOnboarded.title
-              : product.title
-          }
-          description={
-            baseProductWithExistingSubProductNotOnboarded &&
-            existingSubProductNotOnboarded.description
-              ? existingSubProductNotOnboarded.description
-              : product.description
-          }
-          disableBtn={false}
-          btnAction={() => {
-            const prodID = baseProductWithExistingSubProductNotOnboarded
-              ? existingSubProductNotOnboarded.id
-              : product.id;
-            void getOnboardingStatus(prodID ?? '');
-          }}
-          buttonLabel={t('overview.notActiveProducts.joinButton')}
-          urlPublic={product.urlPublic}
-          product={product}
-        />
-      </Grid>
-    </>
+    <Grid item xs={12} sm={6} lg={4} xl={3} key={product.id}>
+      <NotActiveProductCard
+        image={displayProduct.imageUrl}
+        urlLogo={displayProduct.logo ?? product.logo}
+        title={displayProduct.title ?? product.title}
+        description={displayProduct.description ?? product.description}
+        disableBtn={false}
+        btnAction={() => {
+          void getOnboardingStatus(displayProduct.id ?? product.id);
+        }}
+        buttonLabel={t('overview.notActiveProducts.joinButton')}
+        urlPublic={displayProduct.urlPublic}
+        product={product}
+      />
+    </Grid>
   );
 }

--- a/src/pages/dashboardOverview/components/notActiveProductsSection/components/productFilters.ts
+++ b/src/pages/dashboardOverview/components/notActiveProductsSection/components/productFilters.ts
@@ -2,6 +2,7 @@ import { OnboardedProduct } from '../../../../../api/generated/b4f-dashboard/Onb
 import { OnboardedProductResource } from '../../../../../api/generated/b4f-dashboard/OnboardedProductResource';
 import { StatusEnum } from '../../../../../api/generated/b4f-dashboard/SubProductResource';
 import { Product, ProductInstitutionMap } from '../../../../../model/Product';
+import { PRODUCT_IDS } from '../../../../../utils/constants';
 
 type FilterConfig = {
   institutionType: string;
@@ -32,17 +33,26 @@ const institutionTypeFilter = (
 
 const onboardingStatusFilter = (
   productsWithStatusActive: Array<Product>,
-  onboardedProducts: Array<OnboardedProductResource>
+  onboardedProducts: Array<OnboardedProductResource>,
+  institutionType: string
 ): Array<Product> => {
   const onboardedProductIds = onboardedProducts.map((p) => p.productId);
 
   return productsWithStatusActive.filter((product) => {
     // For productsWithStatusActive with active base version, show eligible children
     if (product.subProducts && product.subProducts?.length > 0) {
-      return product.subProducts.some(
-        (child) =>
-          !onboardedProductIds.includes(child.id ?? '') && child.status === StatusEnum.ACTIVE
-      );
+      return product.subProducts.some((child) => {
+        if (product.id === PRODUCT_IDS.PAGOPA && child.id === PRODUCT_IDS.PAGOPA_INSIGHTS) {
+          return (
+            institutionType === 'PSP' &&
+            !onboardedProductIds.includes(child.id) &&
+            child.status === StatusEnum.ACTIVE
+          );
+        }
+
+        // Default check for other child products
+        return !onboardedProductIds.includes(child.id ?? '') && child.status === StatusEnum.ACTIVE;
+      });
     }
 
     // Exclude productsWithStatusActive that are already onboarded
@@ -64,5 +74,6 @@ export const filterProducts = (
 ): Array<Product> =>
   onboardingStatusFilter(
     institutionTypeFilter(productsWithStatusActive, config),
-    onboardedProducts
+    onboardedProducts,
+    config.institutionType
   );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -26,5 +26,6 @@ export const interopProductIdList = [
 
 export const PRODUCT_IDS = {
   PAGOPA: 'prod-pagopa',
+  PAGOPA_INSIGHTS: 'prod-pagopa-insights',
   IO: 'prod-io',
 } as const;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add check for instituion type PSP
optimize code for not active product cards
<!--- Describe your changes in detail -->

#### Motivation and Context
The pagopa insights service is only avaible to psp institutions so the y can se transaction data.
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.