### PR TITLE
[SELC-6714] feat: confirmation modal for add delegate

### DIFF
--- a/e2e/tests/access-product-backoffice.spec.ts
+++ b/e2e/tests/access-product-backoffice.spec.ts
@@ -3,8 +3,6 @@ import { login } from '../utils/login';
 
 test('user can access backoffice of pagopa', async ({ page }) => {
   await login(page, 'msisti', 'test');
-  await page.getByRole('button', { name: 'Invia' }).click();
-  await page.getByRole('button', { name: 'Invia' }).click();
   await page.getByRole('button', { name: 'Anpal Servizi SpA.' }).click();
   await page.getByRole('button', { name: 'Accedi' }).click();
   await page.getByRole('button', { name: 'Anpal Servizi SpA.' }).click();

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -296,6 +296,12 @@ export default {
     delegationSuccessfulCreated: 'Delega aggiunta correttamente.',
     delegationNotCreated: 'Non è stato possibile aggiungere la delega. Riprova.',
     alreadyDelegated: 'Il Partner selezionato risulta già associato all’ente.',
+    confirmModal: {
+      title: 'Confermi la delega?',
+      description: `Delegando la gestione del prodotto <1>{{productName}}</1> per l’ente <2>{{institutionName}}</2> a <3>{{partnerName}}</3>.<4/> Se confermi, {{partnerName}} potrà gestire il prodotto per conto del tuo ente.`,
+      confirmButton: 'Conferma',
+      backButton: 'Indietro',
+    },
   },
   subHeader: {
     partySelectionSearch: {

--- a/src/pages/dashboardDelegations/dashboardDelegationsAdd/components/AddDelegationForm.tsx
+++ b/src/pages/dashboardDelegations/dashboardDelegationsAdd/components/AddDelegationForm.tsx
@@ -154,10 +154,10 @@ export default function AddDelegationForm({
       .finally(() => setLoading(false));
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     if (productSelected && techPartnerSelected) {
       setLoading(true);
-      await createDelegation(party, productSelected, techPartnerSelected)
+      createDelegation(party, productSelected, techPartnerSelected)
         .then(() => {
           addNotify({
             component: 'Toast',
@@ -187,7 +187,34 @@ export default function AddDelegationForm({
         .finally(() => setLoading(false));
     }
   };
-
+  const confirmAddDelegateModal = () => {
+    addNotify({
+      component: 'SessionModal',
+      id: 'Notify_Example',
+      title: t('addDelegationPage.confirmModal.title'),
+      message: (
+        <Trans
+          i18nKey="addDelegationPage.confirmModal.description"
+          values={{
+            productName: productSelected?.title,
+            institutionName: party.description,
+            partnerName: techPartnerSelected?.description,
+          }}
+          components={{
+            1: <strong />,
+            2: <strong />,
+            3: <strong />,
+            4: <br />,
+          }}
+        >
+          {`Delegando la gestione del prodotto <1>{{productName}}</1> per l’ente <2>{{institutionName}}</2> a <3>{{partnerName}}</3>.<4/> Se confermi, {{partnerName}} potrà gestire il prodotto per conto del tuo ente.`}
+        </Trans>
+      ),
+      confirmLabel: t('addDelegationPage.confirmModal.confirmButton'),
+      closeLabel: t('addDelegationPage.confirmModal.backButton'),
+      onConfirm: () => handleSubmit(),
+    });
+  };
   return (
     <>
       <Grid container sx={{ backgroundColor: 'background.paper' }} p={3}>
@@ -429,7 +456,7 @@ export default function AddDelegationForm({
         </Button>
         <Button
           disabled={!productSelected || !techPartnerSelected}
-          onClick={() => handleSubmit()}
+          onClick={() => confirmAddDelegateModal()}
           color="primary"
           variant="contained"
           type="submit"

--- a/src/pages/dashboardDelegations/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
+++ b/src/pages/dashboardDelegations/dashboardDelegationsAdd/components/__tests__/AddDelegationsForm.test.tsx
@@ -23,13 +23,13 @@ test('render the form correctly woth empty props', () => {
 test('search by name', async () => {
   renderWithProviders(
     <AddDelegationForm
-      productsWithCreateDelegationAction={[mockedPartyProducts[0]]}
+      productsWithCreateDelegationAction={[mockedPartyProducts[2]]}
       party={mockedParties[2]}
-      selectedProductByQuery={mockedPartyProducts[0]}
+      selectedProductByQuery={mockedPartyProducts[2]}
     />
   );
 
-  expect(screen.getByText('IO')).toBeInTheDocument();
+  expect(screen.getByText('Pagamenti pagoPA')).toBeInTheDocument();
   const autocompleteInput = screen.getByLabelText(
     'Inserisci la ragione sociale'
   ) as HTMLInputElement;
@@ -42,6 +42,10 @@ test('search by name', async () => {
 
   userEvent.type(autocompleteInput, 'Maggi');
   fireEvent.change(autocompleteInput, { target: { value: 'Maggi' } });
+
+  const confirmDelegationBtn = await screen.findByText('Conferma');
+  expect(confirmDelegationBtn).toBeInTheDocument();
+  fireEvent.click(confirmDelegationBtn);
 });
 
 test('search by fiscal code', async () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Modal to cofirm before adding delegate
Moved api cal into modal onClick
updated unit tests
<!--- Describe your changes in detail -->

#### Motivation and Context
At the moment Its not possible to remove a delegate once added. A confirmation modal was created so the user does not add delegates by mistake.
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.