### PR TITLE
[SELC-6792] fix: fetch product roles for prod pagopa

### DIFF
--- a/src/hooks/__tests__/useProductRolesMap.test.tsx
+++ b/src/hooks/__tests__/useProductRolesMap.test.tsx
@@ -1,0 +1,69 @@
+import { usePermissions } from '@pagopa/selfcare-common-frontend/lib';
+import useReduxCachedValue from '@pagopa/selfcare-common-frontend/lib/hooks/useReduxCachedValue';
+import { useAppSelector } from '../../redux/hooks';
+import { fetchProductRoles } from '../../services/productService';
+import { useProductsRolesMap } from '../useProductsRolesMap';
+
+jest.mock('../../redux/hooks', () => ({
+  useAppSelector: jest.fn(),
+}));
+
+jest.mock('@pagopa/selfcare-common-frontend/lib', () => ({
+  usePermissions: jest.fn(),
+}));
+
+jest.mock('@pagopa/selfcare-common-frontend/lib/hooks/useReduxCachedValue', () => jest.fn());
+
+jest.mock('../../services/productService', () => ({
+  fetchProductRoles: jest.fn(),
+}));
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useMemo: jest.fn((fn) => fn()),
+}));
+
+describe('useProductsRolesMap', () => {
+  const mockHasPermission = jest.fn();
+  const mockUseReduxCachedValue = jest.fn();
+  const mockFetchProductRoles = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (usePermissions as jest.Mock).mockReturnValue({
+      hasPermission: mockHasPermission,
+    });
+    (useReduxCachedValue as jest.Mock).mockImplementation(mockUseReduxCachedValue);
+    (fetchProductRoles as jest.Mock).mockResolvedValue([]);
+
+    (useAppSelector as jest.Mock)
+      .mockImplementationOnce(() => ({
+        id: 'test-party',
+        products: [
+          {
+            productId: 'product1',
+            productOnBoardingStatus: 'ACTIVE',
+          },
+        ],
+      }))
+      .mockImplementationOnce(() => [
+        {
+          id: 'product1',
+          name: 'Test Product',
+        },
+      ])
+      .mockImplementationOnce(() => ({}));
+  });
+
+  it('should skip product role fetch if no active and accessible products', async () => {
+    (useAppSelector as jest.Mock)
+      .mockImplementationOnce(() => ({ products: [] }))
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => ({}));
+
+    useProductsRolesMap();
+
+    expect(fetchProductRoles).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProductsRolesMap.tsx
+++ b/src/hooks/useProductsRolesMap.tsx
@@ -59,8 +59,7 @@ export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
       (state.parties.selectedProductsRolesMap &&
         !activeAndAccessibleProducts.find(
           (p) =>
-            !(state.parties.selectedProductsRolesMap as ProductsRolesMap)[p.id] ||
-            productsRolesMap[PRODUCT_IDS.PAGOPA]
+            !state.parties.selectedProductsRolesMap?.[p.id] || productsRolesMap[PRODUCT_IDS.PAGOPA]
         ))
         ? state.parties.selectedProductsRolesMap
         : undefined,

--- a/src/hooks/useProductsRolesMap.tsx
+++ b/src/hooks/useProductsRolesMap.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from '../redux/hooks';
 import { partiesActions, partiesSelectors } from '../redux/slices/partiesSlice';
 import { RootState } from '../redux/store';
 import { fetchProductRoles } from '../services/productService';
+import { PRODUCT_IDS } from '../utils/constants';
 
 export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
   const party = useAppSelector(partiesSelectors.selectPartySelected);
@@ -38,7 +39,7 @@ export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
     }
 
     const promises: Array<Promise<[string, ProductRolesLists]>> = activeAndAccessibleProducts
-      .filter((p) => !productsRolesMap[p.id])
+      .filter((p) => !productsRolesMap[p.id] || productsRolesMap[PRODUCT_IDS.PAGOPA])
       .map((p) =>
         fetchProductRoles(p, party as Party).then((roles) => [
           p.id,
@@ -57,7 +58,9 @@ export const useProductsRolesMap = (): (() => Promise<ProductsRolesMap>) => {
       !activeAndAccessibleProducts ||
       (state.parties.selectedProductsRolesMap &&
         !activeAndAccessibleProducts.find(
-          (p) => !(state.parties.selectedProductsRolesMap as ProductsRolesMap)[p.id]
+          (p) =>
+            !(state.parties.selectedProductsRolesMap as ProductsRolesMap)[p.id] ||
+            productsRolesMap[PRODUCT_IDS.PAGOPA]
         ))
         ? state.parties.selectedProductsRolesMap
         : undefined,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
add exception for prod pagopa when caching roles configuration
<!--- Describe your changes in detail -->

#### Motivation and Context
prod pagoPa ha sifferent roles based on instituion type. When switching from two instituions that had prod-pagopa as a active product the FE would not refetch the roles as it was already cached. 
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.